### PR TITLE
Use Gtk.Application instead of Granite.Application

### DIFF
--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -1,19 +1,11 @@
 namespace Monitor {
 
-    public class MonitorApp : Granite.Application {
+    public class MonitorApp : Gtk.Application {
         private MainWindow window = null;
         public string[] args;
 
         construct {
-            program_name = "Monitor";
             application_id = "com.github.stsdc.monitor";
-            exec_name = "com.github.stsdc.monitor";
-            app_launcher = application_id + ".desktop";
-        }
-
-        public MonitorApp () {
-            Granite.Services.Logger.initialize (this.program_name);
-            Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.DEBUG;
         }
 
         public override void activate () {


### PR DESCRIPTION
Since [Granite.Application is officially deprecated](https://github.com/elementary/granite/blob/3c25b6c95e5ddf3fcc3bdf8bf1014f6d2246e677/lib/Application.vala#L25) since 0.5.0.