### PR TITLE
Valign widgets in the headerbar

### DIFF
--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -15,6 +15,7 @@ namespace Monitor {
             var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
             var kill_process_button = new Gtk.Button.with_label (_("End process"));
+            kill_process_button.valign = Gtk.Align.CENTER;
             kill_process_button.clicked.connect (window.process_view.kill_process);
             kill_process_button.tooltip_text = (_("Ctrl+E"));
 
@@ -22,6 +23,7 @@ namespace Monitor {
             pack_start (button_box);
 
             search = new Search (window.process_view, window.generic_model);
+            search.valign = Gtk.Align.CENTER;
             pack_end (search);
         }
     }


### PR DESCRIPTION
These lines are needed for Juno (Gtk+ 3.22)

### Before

![screenshot from 2018-10-20 22-53-11](https://user-images.githubusercontent.com/26003928/47262225-7d6f1580-d51d-11e8-8997-66f6956b1de9.png)

### After

![screenshot from 2018-10-20 22-52-57](https://user-images.githubusercontent.com/26003928/47262224-7cd67f00-d51d-11e8-875e-e9578142944c.png)
