### PR TITLE
Fix POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,12 +1,13 @@
 src/Monitor.vala
 src/MainWindow.vala
+src/Widgets/Headerbar.vala
 src/Widgets/OverallView.vala
 src/Widgets/Search.vala
 src/Widgets/Statusbar.vala
-src/Models/ApplicationProcessModel.vala
 src/Managers/AppManager.vala
 src/Managers/ProcessManager.vala
 src/Managers/Process.vala
+src/Models/GenericModel.vala
 src/Services/Settings.vala
 src/Services/Shortcuts.vala
 src/Services/Resources.vala


### PR DESCRIPTION
## Changes Summary

* Remove `src/Models/ApplicationProcessModel.vala` which is not seems to be exist from the list
* Add `src/Widgets/Headerbar.vala` and `src/Models/GenericModel.vala` to the list in order to make strings like "Background Applications", "End process" (button), "Ctrl+E" (tooltip), and "Monitor" (the title of the headerbar) translatable.

I will recommend you to update all translation files after merging this PR.
