### PR TITLE
Allow to set start in background option from UI

### DIFF
--- a/data/com.github.stsdc.monitor.gschema.xml
+++ b/data/com.github.stsdc.monitor.gschema.xml
@@ -25,5 +25,10 @@
       <summary>To show Monitor Indicator or not</summary>
       <description>To show Monitor Indicator or not</description>
     </key>
+    <key type='b' name="background-state">
+      <default>false</default>
+      <summary>To start Monitor in background or not</summary>
+      <description>To start Monitor in background or not</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -31,13 +31,14 @@ namespace Monitor {
 
             window = new MainWindow (this);
 
-            //start in background with indicator
-            if (status_background) {
+            // start in background with indicator
+            if (status_background || window.saved_state.background_state) {
                 if (!window.saved_state.indicator_state) {
                     window.saved_state.indicator_state = true;
                 }
 
                 window.hide ();
+                window.saved_state.background_state = true;
             } else {
                 window.show_all ();
             }

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -11,6 +11,8 @@ namespace Monitor {
 
         public bool indicator_state { get; set; }
 
+        public bool background_state { get; set; }
+
         construct {
             // Controls the direction of the sort indicators
             Gtk.Settings.get_default ().set ("gtk-alternative-sort-arrows", true, null);

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -41,14 +41,23 @@ namespace Monitor {
             preferences_popover.add (preferences_grid);
             preferences_button.popover = preferences_popover;
 
+            var indicator_label = new Gtk.Label (_("Show an indicator:"));
+            indicator_label.halign = Gtk.Align.END;
+
             var show_indicator_switch = new Gtk.Switch ();
             show_indicator_switch.state = window.saved_state.indicator_state;
 
-            var switch_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 10);
-            switch_box.pack_start (new Gtk.Label (_("Show an indicator")), false, false, 0);
-            switch_box.pack_start (show_indicator_switch, false, false, 0);
+            var background_label = new Gtk.Label (_("Start in background:"));
+            background_label.halign = Gtk.Align.END;
 
-            preferences_grid.add (switch_box);
+            var background_switch = new Gtk.Switch ();
+            background_switch.state = window.saved_state.background_state;
+
+            preferences_grid.attach (indicator_label, 0, 0, 1, 1);
+            preferences_grid.attach (show_indicator_switch, 1, 0, 1, 1);
+            preferences_grid.attach (background_label, 0, 1, 1, 1);
+            preferences_grid.attach (background_switch, 1, 1, 1, 1);
+
             preferences_grid.show_all ();
 
             search = new Search (window.process_view, window.generic_model);
@@ -58,6 +67,9 @@ namespace Monitor {
             show_indicator_switch.notify["active"].connect (() => {
                 window.saved_state.indicator_state = show_indicator_switch.state;
                 window.dbusserver.indicator_state (show_indicator_switch.state);
+            });
+            background_switch.notify["active"].connect (() => {
+                window.saved_state.background_state = background_switch.state;
             });
         }
     }

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -2,6 +2,8 @@ namespace Monitor {
 
     public class Headerbar : Gtk.HeaderBar {
         private MainWindow window;
+        private Gtk.Switch show_indicator_switch;
+        private Gtk.Switch background_switch;
 
         public Search search;
 
@@ -44,14 +46,15 @@ namespace Monitor {
             var indicator_label = new Gtk.Label (_("Show an indicator:"));
             indicator_label.halign = Gtk.Align.END;
 
-            var show_indicator_switch = new Gtk.Switch ();
+            show_indicator_switch = new Gtk.Switch ();
             show_indicator_switch.state = window.saved_state.indicator_state;
 
             var background_label = new Gtk.Label (_("Start in background:"));
             background_label.halign = Gtk.Align.END;
 
-            var background_switch = new Gtk.Switch ();
+            background_switch = new Gtk.Switch ();
             background_switch.state = window.saved_state.background_state;
+            set_background_switch_state ();
 
             preferences_grid.attach (indicator_label, 0, 0, 1, 1);
             preferences_grid.attach (show_indicator_switch, 1, 0, 1, 1);
@@ -67,18 +70,20 @@ namespace Monitor {
             show_indicator_switch.notify["active"].connect (() => {
                 window.saved_state.indicator_state = show_indicator_switch.state;
                 window.dbusserver.indicator_state (show_indicator_switch.state);
-
-                if (!show_indicator_switch.active && background_switch.active) {
-                    background_switch.active = false;
-                }
+                set_background_switch_state ();
             });
             background_switch.notify["active"].connect (() => {
                 window.saved_state.background_state = background_switch.state;
-
-                if (!show_indicator_switch.active && background_switch.active) {
-                    show_indicator_switch.active = true;
-                }
+                set_background_switch_state ();
             });
+        }
+
+        private void set_background_switch_state () {
+            background_switch.sensitive = show_indicator_switch.active;
+
+            if (!show_indicator_switch.active) {
+                background_switch.state = false;
+            }
         }
     }
 }

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -67,9 +67,17 @@ namespace Monitor {
             show_indicator_switch.notify["active"].connect (() => {
                 window.saved_state.indicator_state = show_indicator_switch.state;
                 window.dbusserver.indicator_state (show_indicator_switch.state);
+
+                if (!show_indicator_switch.active && background_switch.active) {
+                    background_switch.active = false;
+                }
             });
             background_switch.notify["active"].connect (() => {
                 window.saved_state.background_state = background_switch.state;
+
+                if (!show_indicator_switch.active && background_switch.active) {
+                    show_indicator_switch.active = true;
+                }
             });
         }
     }


### PR DESCRIPTION
From https://github.com/stsdc/monitor/pull/84#issuecomment-475360114:
> Anyway, this option should be also available in Settings popup (maybe in another PR).

### BEFORE

![Screenshot from 2019-04-07 14-33-44](https://user-images.githubusercontent.com/26003928/55679197-372e3700-5942-11e9-9fa8-9384e3ef1341.png)

### AFTER

![Screenshot from 2019-04-07 14-31-43](https://user-images.githubusercontent.com/26003928/55679183-e8809d00-5941-11e9-9bc8-d28dc5aa56f8.png)

### Changes Summary

* Allow to set start in background option from UI
* Add `:` at the end of labels that come with switches to be consistent with elementary
* Organize UI in the popover
