### PR TITLE
Added buttons to either "kill" or "end" a process.

### DIFF
--- a/src/Managers/Process.vala
+++ b/src/Managers/Process.vala
@@ -59,7 +59,18 @@ namespace Monitor {
         // Kills the process
         // Returns if kill was successful
         public bool kill () {
-            if (Posix.kill (pid, Posix.Signal.INT) == 0) {
+            //  Sends a kill signal that cannot be ignored
+            if (Posix.kill (pid, Posix.Signal.KILL) == 0) {
+                return true;
+            }
+            return false;
+        }
+
+        // Ends the process
+        // Returns if end was successful
+        public bool end () {
+            //  Sends a terminate signal
+            if (Posix.kill (pid, Posix.Signal.TERM) == 0) {
                 return true;
             }
             return false;

--- a/src/Models/GenericModel.vala
+++ b/src/Models/GenericModel.vala
@@ -280,7 +280,15 @@ namespace Monitor {
                 process.kill ();
                 info ("Kill:%d",process.pid);
             }
-}
+        }
+
+        public void end_process (int pid) {
+            if (pid > 0) {
+                var process = process_manager.get_process (pid);
+                process.end ();
+                info ("End:%d",process.pid);
+            }
+        }
     }
 
 }

--- a/src/Services/Shortcuts.vala
+++ b/src/Services/Shortcuts.vala
@@ -22,6 +22,10 @@ namespace Monitor {
                         handled = true;
                         break;
                     case Gdk.Key.e:
+                        window.process_view.end_process ();
+                        handled = true;
+                        break;
+                    case Gdk.Key.k:
                         window.process_view.kill_process ();
                         handled = true;
                         break;

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -30,7 +30,7 @@ namespace Monitor {
             kill_process_button.valign = Gtk.Align.CENTER;
             end_process_button.halign = Gtk.Align.END;
             kill_process_button.clicked.connect (window.process_view.kill_process);
-            kill_process_button.tooltip_text = (_("Ctrl+E"));
+            kill_process_button.tooltip_text = (_("Ctrl+K"));
             var kill_process_button_context = kill_process_button.get_style_context ();
             kill_process_button_context.add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -16,10 +16,9 @@ namespace Monitor {
         public Headerbar (MainWindow window) {
             this.window = window;
             var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+            button_box.valign = Gtk.Align.CENTER;
 
             var end_process_button = new Gtk.Button.with_label (_("End Process"));
-            end_process_button.valign = Gtk.Align.CENTER;
-            end_process_button.halign = Gtk.Align.START;
             end_process_button.margin_end = 10;
             end_process_button.clicked.connect (window.process_view.end_process);
             end_process_button.tooltip_text = (_("Ctrl+E"));
@@ -27,15 +26,13 @@ namespace Monitor {
             end_process_button_context.add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
             var kill_process_button = new Gtk.Button.with_label (_("Kill Process"));
-            kill_process_button.valign = Gtk.Align.CENTER;
-            end_process_button.halign = Gtk.Align.END;
             kill_process_button.clicked.connect (window.process_view.kill_process);
             kill_process_button.tooltip_text = (_("Ctrl+K"));
             var kill_process_button_context = kill_process_button.get_style_context ();
             kill_process_button_context.add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
-            button_box.add (end_process_button);
-            button_box.add (kill_process_button);
+            button_box.pack_start (end_process_button);
+            button_box.pack_end (kill_process_button);
             pack_start (button_box);
 
             var preferences_button = new Gtk.MenuButton ();

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -17,13 +17,24 @@ namespace Monitor {
             this.window = window;
             var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-            var kill_process_button = new Gtk.Button.with_label (_("End process"));
+            var end_process_button = new Gtk.Button.with_label (_("End Process"));
+            end_process_button.valign = Gtk.Align.CENTER;
+            end_process_button.halign = Gtk.Align.START;
+            end_process_button.margin_end = 10;
+            end_process_button.clicked.connect (window.process_view.end_process);
+            end_process_button.tooltip_text = (_("Ctrl+E"));
+            var end_process_button_context = end_process_button.get_style_context ();
+            end_process_button_context.add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+            var kill_process_button = new Gtk.Button.with_label (_("Kill Process"));
             kill_process_button.valign = Gtk.Align.CENTER;
+            end_process_button.halign = Gtk.Align.END;
             kill_process_button.clicked.connect (window.process_view.kill_process);
             kill_process_button.tooltip_text = (_("Ctrl+E"));
             var kill_process_button_context = kill_process_button.get_style_context ();
             kill_process_button_context.add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
+            button_box.add (end_process_button);
             button_box.add (kill_process_button);
             pack_start (button_box);
 

--- a/src/Widgets/OverallView.vala
+++ b/src/Widgets/OverallView.vala
@@ -176,5 +176,10 @@ namespace Monitor {
             model.kill_process (pid);
         }
 
+        public void end_process () {
+            int pid = get_pid_of_selected ();
+            model.end_process (pid);
+        }
+
     }
 }


### PR DESCRIPTION
A possible implementation to address #79.
![image](https://user-images.githubusercontent.com/18509589/58138007-7ec30680-7c02-11e9-81d6-844f2b91700b.png)

The design is not not final but it is a simple solution to offering both options.

More importantly, I changed the signal that is sent from `Posix.kill (pid, Posix.Signal.INT)` to `Posix.kill (pid, Posix.Signal.KILL)` to send a kill signal rather than an interrupt signal. The "end process" button sends a `Posix.kill (pid, Posix.Signal.TERM)`. These are the signals used in other system monitors such as gnome-system-monitor. I found these details [here](https://askubuntu.com/a/716814).
