### PR TITLE
Fix the app crashes by clicking the "End/Kill Process" buttons when no process is selected

### DIFF
--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -43,6 +43,8 @@ namespace Monitor {
                 window.show_all ();
             }
 
+            window.process_view.focus_on_first_row ();
+
             var quit_action = new SimpleAction ("quit", null);
             add_action (quit_action);
             set_accels_for_action ("app.quit", {"<Ctrl>q"});

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -2,6 +2,7 @@ namespace Monitor {
 
     public class Headerbar : Gtk.HeaderBar {
         private MainWindow window;
+        private Gtk.Button kill_process_button;
         private Gtk.Switch show_indicator_switch;
         private Gtk.Switch background_switch;
 
@@ -17,7 +18,7 @@ namespace Monitor {
             this.window = window;
             var button_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
 
-            var kill_process_button = new Gtk.Button.with_label (_("End process"));
+            kill_process_button = new Gtk.Button.with_label (_("End process"));
             kill_process_button.valign = Gtk.Align.CENTER;
             kill_process_button.clicked.connect (window.process_view.kill_process);
             kill_process_button.tooltip_text = (_("Ctrl+E"));
@@ -63,7 +64,7 @@ namespace Monitor {
 
             preferences_grid.show_all ();
 
-            search = new Search (window.process_view, window.generic_model);
+            search = new Search (window);
             search.valign = Gtk.Align.CENTER;
             pack_end (search);
 
@@ -84,6 +85,10 @@ namespace Monitor {
             if (!show_indicator_switch.active) {
                 background_switch.state = false;
             }
+        }
+
+        public void set_kill_process_button_sensitivity (bool sensitivity) {
+            kill_process_button.sensitive = sensitivity;
         }
     }
 }

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -2,6 +2,7 @@ namespace Monitor {
 
     public class Headerbar : Gtk.HeaderBar {
         private MainWindow window;
+        private Gtk.Button end_process_button;
         private Gtk.Button kill_process_button;
         private Gtk.Switch show_indicator_switch;
         private Gtk.Switch background_switch;
@@ -26,7 +27,7 @@ namespace Monitor {
             var end_process_button_context = end_process_button.get_style_context ();
             end_process_button_context.add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
-            var kill_process_button = new Gtk.Button.with_label (_("Kill Process"));
+            kill_process_button = new Gtk.Button.with_label (_("Kill Process"));
             kill_process_button.clicked.connect (window.process_view.kill_process);
             kill_process_button.tooltip_text = (_("Ctrl+K"));
             var kill_process_button_context = kill_process_button.get_style_context ();
@@ -95,7 +96,8 @@ namespace Monitor {
             }
         }
 
-        public void set_kill_process_button_sensitivity (bool sensitivity) {
+        public void set_header_buttons_sensitivity (bool sensitivity) {
+            end_process_button.sensitive = sensitivity;
             kill_process_button.sensitive = sensitivity;
         }
     }

--- a/src/Widgets/Search.vala
+++ b/src/Widgets/Search.vala
@@ -35,10 +35,12 @@ namespace Monitor {
                 // if there's no search result, make "Kill/End Process" buttons in headerbar insensitive to avoid the app crashes
                 window.headerbar.set_header_buttons_sensitivity (filter_model.iter_n_children (null) != 0);
 
-                // when search word is cleared, focus on child row to avoid the app crashes by clicking "Kill/End Process" buttons in headerbar
-                if (this.text == "") {
-                    process_view.focus_on_child_row ();
-                    this.grab_focus ();
+                // focus on child row to avoid the app crashes by clicking "Kill/End Process" buttons in headerbar
+                process_view.focus_on_child_row ();
+                this.grab_focus ();
+
+                if (this.text != "") {
+                    this.insert_at_cursor ("");
                 }
             });
         }

--- a/src/Widgets/Search.vala
+++ b/src/Widgets/Search.vala
@@ -32,10 +32,10 @@ namespace Monitor {
 
                 filter_model.refilter ();
 
-                // if there's no search result, make kill_process_button insensitive to avoid the app crashes
-                window.headerbar.set_kill_process_button_sensitivity (filter_model.iter_n_children (null) != 0);
+                // if there's no search result, make "Kill/End Process" buttons in headerbar insensitive to avoid the app crashes
+                window.headerbar.set_header_buttons_sensitivity (filter_model.iter_n_children (null) != 0);
 
-                // when search word is cleared, focus on child row to avoid the app crashes by clicking kill_process_button
+                // when search word is cleared, focus on child row to avoid the app crashes by clicking "Kill/End Process" buttons in headerbar
                 if (this.text == "") {
                     process_view.focus_on_child_row ();
                     this.grab_focus ();


### PR DESCRIPTION
Fixes #97

## BEFORE

![2019-05-29 13 37 27 の画面録画](https://user-images.githubusercontent.com/26003928/58529796-3e254780-8217-11e9-9509-554bc213d216.gif)

The app crashes by clicking the "End/Kill Process" button when there's no search result.

![2019-05-29 13 38 16 の画面録画](https://user-images.githubusercontent.com/26003928/58529797-3e254780-8217-11e9-9424-b8a166ebc0ac.gif)

The app also crashes by clicking the "End/Kill process" button when no process is selected after clearing search text.

## AFTER

![2019-05-29 13 33 08 の画面録画](https://user-images.githubusercontent.com/26003928/58529793-3d8cb100-8217-11e9-97cc-2fccf68ff6f4.gif)

The app no longer crashes by clicking the "End/Kill process" button when there's no search result.

![2019-05-29 13 34 14 の画面録画](https://user-images.githubusercontent.com/26003928/58529795-3e254780-8217-11e9-8a3c-2ea726b74315.gif)

The app now selects the first row after clearing search text.

## ~~TODO~~

~~Although now the "End/Kill Process" button is insensitive if there's no search result, the color of it does not turn to the one it should be. Its color should change like this demo:~~

![2019-05-24 22 14 53 の画面録画](https://user-images.githubusercontent.com/26003928/58330225-69074880-7e71-11e9-8a17-4c4a051304a9.gif)

~~I'm not sure why this does not work.~~ :thinking: 
