### PR TITLE
Fix contents of the window are not shown

### DIFF
--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -25,6 +25,7 @@ namespace Monitor {
         public override void activate () {
             // only have one window
             if (get_windows () != null) {
+                window.show_all ();
                 window.present ();
                 return;
             }


### PR DESCRIPTION
![Screenshot from 2019-06-03 18-01-46](https://user-images.githubusercontent.com/26003928/58790080-9cdd2d80-862a-11e9-9601-9155b2c013c0.png)

## Steps to Reproduce The Issue

* Enable "Show an indicator" and "Start in background" options
* Logout and re-login
* Launch Monitor from Applications Menu and start indicator
* Launch Monitor from Applications Menu to show the UI
* The window without any content is shown
