### PR TITLE
Fix warnings

### DIFF
--- a/src/Indicator/Indicator.vala
+++ b/src/Indicator/Indicator.vala
@@ -26,13 +26,21 @@ public class Monitor.Indicator : Wingpanel.Indicator {
         });
 
         popover_widget.quit_monitor.connect (() => {
-            dbusclient.interface.quit_monitor ();
-            this.visible = false;
+            try {
+                dbusclient.interface.quit_monitor ();
+                this.visible = false;
+            } catch (Error e) {
+                warning (e.message);
+            }
         });
 
         popover_widget.show_monitor.connect (() => {
-            close ();
-            dbusclient.interface.show_monitor ();
+            try {
+                close ();
+                dbusclient.interface.show_monitor ();
+            } catch (Error e) {
+                warning (e.message);
+            }
         });
 
     }
@@ -64,15 +72,6 @@ public class Monitor.Indicator : Wingpanel.Indicator {
     public override void closed () {
     }
 
-    /* Method to connect the signals */
-    private void connect_signals () {
-        /* Connect to the click signal of the hide button */
-        // hide_button.clicked.connect (hide_me);
-
-        /* Connect to the switch signal of the compositing switch */
-        // compositing_switch.switched.connect (update_compositing);
-    }
-
     /* Method to hide the indicator for a short time */
     // private void hide_me () {
     //     /* Hide the indicator */
@@ -87,12 +86,6 @@ public class Monitor.Indicator : Wingpanel.Indicator {
     //         return false;
     //     });
     // }
-
-    /* Method to check the status of the compositing switch and update the indicator */
-    private void update_compositing () {
-        /* If the switch is enabled set the icon name of the icon that should be drawn on top of the other one, if not hide the top icon. */
-        // display_widget.set_overlay_icon_name (compositing_switch.get_active () ? "nm-vpn-active-lock" : "");
-    }
 }
 
 /*

--- a/src/Indicator/Services/DBusClient.vala
+++ b/src/Indicator/Services/DBusClient.vala
@@ -1,7 +1,7 @@
 [DBus (name = "com.github.stsdc.monitor")]
 public interface Monitor.DBusClientInterface : Object {
-    public abstract void quit_monitor () throws IOError;
-    public abstract void show_monitor () throws IOError;
+    public abstract void quit_monitor () throws Error;
+    public abstract void show_monitor () throws Error;
     public signal void update (Utils.SystemResources data);
     public signal void indicator_state (bool state);
 }

--- a/src/Indicator/Widgets/DisplayWidget.vala
+++ b/src/Indicator/Widgets/DisplayWidget.vala
@@ -1,7 +1,4 @@
 public class Monitor.Widgets.DisplayWidget : Gtk.Grid {
-    private Gtk.Revealer percent_revealer;
-    private bool allow_percent = false;
-
     public CPUWidget cpu_widget;
     public MemoryWidget memory_widget;
 
@@ -14,6 +11,5 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Grid {
 
         add (cpu_widget);
         add (memory_widget);
-
     }
 }

--- a/src/Indicator/Widgets/PopoverWidget.vala
+++ b/src/Indicator/Widgets/PopoverWidget.vala
@@ -1,7 +1,7 @@
 public class Monitor.Widgets.PopoverWidget : Gtk.Grid {
     /* Button to hide the indicator */
-    private Wingpanel.Widgets.Button show_monitor_button;
-    private Wingpanel.Widgets.Button quit_monitor_button;
+    private Gtk.ModelButton show_monitor_button;
+    private Gtk.ModelButton quit_monitor_button;
 
     public signal void quit_monitor ();
     public signal void show_monitor ();
@@ -9,8 +9,10 @@ public class Monitor.Widgets.PopoverWidget : Gtk.Grid {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        show_monitor_button = new Wingpanel.Widgets.Button (_("Show Monitor"));
-        quit_monitor_button = new Wingpanel.Widgets.Button (_("Quit Monitor"));
+        show_monitor_button = new Gtk.ModelButton ();
+        show_monitor_button.text = _("Show Monitor");
+        quit_monitor_button = new Gtk.ModelButton ();
+        quit_monitor_button.text = _("Quit Monitor");
         show_monitor_button.clicked.connect (() => show_monitor ());
         quit_monitor_button.clicked.connect (() => quit_monitor ());
 

--- a/src/Widgets/OverallView.vala
+++ b/src/Widgets/OverallView.vala
@@ -79,8 +79,13 @@ namespace Monitor {
             model.get_value (iter, Column.ICON, out icon_name);
             if (regex.match ((string) icon_name)) {
                 string path = ((string) icon_name);
-                Gdk.Pixbuf icon = new Gdk.Pixbuf.from_file_at_size (path, 16, -1);
-                (icon_cell as Gtk.CellRendererPixbuf).pixbuf = icon;
+
+                try {
+                    Gdk.Pixbuf icon = new Gdk.Pixbuf.from_file_at_size (path, 16, -1);
+                    (icon_cell as Gtk.CellRendererPixbuf).pixbuf = icon;
+                } catch (Error e) {
+                    warning (e.message);
+                }
             } else {
                 (icon_cell as Gtk.CellRendererPixbuf).icon_name = (string) icon_name;
             }


### PR DESCRIPTION
* Use `Gtk.ModelButton` instead of `Wingpanel.Widgets.Button` that has been deprecated since 2.0.5
* Throw DBus methods errors to `GLib.Error`
* Fix some unhandled errors `GLib.Error'
* Remove some unused methods and variables
