### PR TITLE
Fix the 'GtkCellAreaBox' warning

### DIFF
--- a/src/Widgets/OverallView.vala
+++ b/src/Widgets/OverallView.vala
@@ -65,7 +65,6 @@ namespace Monitor {
             pid_column.expand = false;
             pid_column.alignment = 0.5f;
             pid_column.set_sort_column_id (Column.PID);
-            pid_column.pack_start (pid_cell, false);
             pid_column.add_attribute (pid_cell, "text", Column.PID);
             insert_column (pid_column, -1);
 


### PR DESCRIPTION
Fixes the following warning is shown on launching the app:

```
(com.github.stsdc.monitor:18613): Gtk-WARNING **: 20:12:16.726: Refusing to add the same cell renderer to a GtkCellAreaBox twice
```
