### PR TITLE
build: fix install path for wingpanel indicator

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -3,17 +3,17 @@ icon_sizes = ['16', '24', '32', '48', '64', '128']
 foreach i : icon_sizes
     install_data(
         join_paths('icons', i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps')
+        install_dir: join_paths(icondir, i + 'x' + i, 'apps')
     )
     install_data(
         join_paths('icons', i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
+        install_dir: join_paths(icondir, i + 'x' + i + '@2', 'apps')
     )
 endforeach
 
 install_data(
     meson.project_name() + '.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )
 
 i18n.merge_file(
@@ -22,7 +22,7 @@ i18n.merge_file(
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     type: 'desktop',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'applications')
+    install_dir: join_paths(datadir, 'applications')
 )
 
 i18n.merge_file(
@@ -30,5 +30,5 @@ i18n.merge_file(
     output: meson.project_name() + '.appdata.xml',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: join_paths(datadir, 'metainfo')
 )

--- a/meson.build
+++ b/meson.build
@@ -112,9 +112,7 @@ shared_module(
         wingpanel
     ],
     install: true,
-    install_dir : wingpanel.get_pkgconfig_variable('indicatorsdir'),
-    # install_dir : '/usr/lib/x86_64-linux-gnu/wingpanel/'
-
+    install_dir : wingpanel.get_pkgconfig_variable('indicatorsdir', define_variable: ['libdir', libdir]),
 )
 
 # Add in a post install script

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,12 @@ project('com.github.stsdc.monitor', 'vala', 'c', version: '0.6.0')
 gnome = import('gnome')
 i18n = import('i18n')
 
+# common dirs
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+icondir = join_paths(datadir, 'icons', 'hicolor')
+
 # and these are project dependencies
 glib = dependency('glib-2.0')
 granite = dependency('granite', version: '>= 5.2.0')


### PR DESCRIPTION
Please read https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/.
I've submitted numerous similar PRs to Pantheon https://github.com/elementary/wingpanel-indicator-a11y/pull/15.