### PR TITLE
Lint codes with vala-lint

### DIFF
--- a/src/Indicator/Indicator.vala
+++ b/src/Indicator/Indicator.vala
@@ -7,7 +7,7 @@ public class Monitor.Indicator : Wingpanel.Indicator {
     private DBusClient dbusclient;
 
     construct {
-        Gtk.IconTheme.get_default().add_resource_path("/com/github/stsdc/monitor/icons");
+        Gtk.IconTheme.get_default ().add_resource_path ("/com/github/stsdc/monitor/icons");
         settings = new Settings ("com.github.stsdc.monitor.settings");
         this.visible = false;
         display_widget = new Widgets.DisplayWidget ();
@@ -18,9 +18,9 @@ public class Monitor.Indicator : Wingpanel.Indicator {
         dbusclient.monitor_vanished.connect (() => this.visible = false);
         dbusclient.monitor_appeared.connect (() => this.visible = settings.get_boolean ("indicator-state"));
 
-        dbusclient.interface.indicator_state.connect((state) => this.visible = state);
+        dbusclient.interface.indicator_state.connect ((state) => this.visible = state);
 
-        dbusclient.interface.update.connect((sysres) => {
+        dbusclient.interface.update.connect ((sysres) => {
             display_widget.cpu_widget.percentage = sysres.cpu_percentage;
             display_widget.memory_widget.percentage = sysres.memory_percentage;
         });

--- a/src/Indicator/Services/DBusClient.vala
+++ b/src/Indicator/Services/DBusClient.vala
@@ -6,7 +6,7 @@ public interface Monitor.DBusClientInterface : Object {
     public signal void indicator_state (bool state);
 }
 
-public class Monitor.DBusClient : Object{
+public class Monitor.DBusClient : Object {
     public DBusClientInterface? interface = null;
 
     private static GLib.Once<DBusClient> instance;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -58,7 +58,7 @@
             this.add (main_box);
 
             updater = Updater.get_default ();
-            dbusserver = DBusServer.get_default();
+            dbusserver = DBusServer.get_default ();
 
             updater.update.connect ((sysres) => {
                 statusbar.update (sysres);
@@ -66,10 +66,10 @@
                 dbusserver.indicator_state (MonitorApp.settings.get_boolean ("indicator-state"));
             });
 
-            dbusserver.quit.connect (() => app.quit());
+            dbusserver.quit.connect (() => app.quit ());
             dbusserver.show.connect (() => {
-                this.deiconify();
-                this.present();
+                this.deiconify ();
+                this.present ();
                 setup_window_state ();
                 this.show_all ();
             });

--- a/src/Managers/AppManager.vala
+++ b/src/Managers/AppManager.vala
@@ -7,79 +7,79 @@ namespace Monitor {
         public int[] pids;
         public uint32 xid;
     }
-	/**
-	 * Wrapper for Bamf.Matcher
-	 */
-	public class AppManager {
-		public signal void application_opened (App app);
-		public signal void application_closed (App app);
+    /**
+     * Wrapper for Bamf.Matcher
+     */
+    public class AppManager {
+        public signal void application_opened (App app);
+        public signal void application_closed (App app);
 
-		static AppManager? app_manager = null;
+        static AppManager? app_manager = null;
         private Bamf.Matcher? matcher;
         private Gee.ArrayList<uint> transient_xids;
 
-		public static AppManager get_default ()	{
-			if (app_manager == null)
-				app_manager = new AppManager ();
-			return app_manager;
-		}
+        public static AppManager get_default () {
+            if (app_manager == null)
+                app_manager = new AppManager ();
+            return app_manager;
+        }
 
 
-		public AppManager () {
+        public AppManager () {
             transient_xids = new Gee.ArrayList<uint> ();
 
-			matcher = Bamf.Matcher.get_default ();
+            matcher = Bamf.Matcher.get_default ();
             matcher.view_opened.connect_after (handle_view_opened);
-			matcher.view_closed.connect_after (handle_view_closed);
-		}
+            matcher.view_closed.connect_after (handle_view_closed);
+        }
 
 
-		~AppManager () {
-			matcher.view_opened.disconnect (handle_view_opened);
-			matcher.view_closed.disconnect (handle_view_closed);
-			matcher = null;
-		}
+        ~AppManager () {
+            matcher.view_opened.disconnect (handle_view_opened);
+            matcher.view_closed.disconnect (handle_view_closed);
+            matcher = null;
+        }
 
         // Function retrieves a Bamf.view, checks if it's a window,
         // then extracts name, icon, desktop_file and pid. After that,
         // sends signal.
 
-		private void handle_view_opened (Bamf.View view) {
+        private void handle_view_opened (Bamf.View view) {
             if (view is Bamf.Window && is_main_window (view)) {
                 int[] win_pids = {};
                 var window = (Bamf.Window)view;
                 var app = matcher.get_application_for_window (window);
-                win_pids += (int)window.get_pid();
+                win_pids += (int)window.get_pid ();
                 if (has_desktop_file (app.get_desktop_file ())) {
-                    debug ("Handle View Opened: %s", view.get_name());
+                    debug ("Handle View Opened: %s", view.get_name ());
                     application_opened (
                         App () {
                             name = app.get_name (),
                             icon = app.get_icon (),
                             desktop_file = app.get_desktop_file (),
                             pids = win_pids,
-                            xid = app.get_xids ().index(0)
+                            xid = app.get_xids ().index (0)
                         }
                     );
                 }
             }
-		}
+        }
 
-		private void handle_view_closed (Bamf.View view) {
+        private void handle_view_closed (Bamf.View view) {
             if (view is Bamf.Window && is_main_window (view)) {
                 int[] win_pids = {};
                 var window = (Bamf.Window)view;
                 var app = matcher.get_application_for_window (window);
-                win_pids += (int)window.get_pid();
+                win_pids += (int)window.get_pid ();
                 if (has_desktop_file (app.get_desktop_file ())) {
-                    debug ("Handle View Closed: %s", view.get_name());
+                    debug ("Handle View Closed: %s", view.get_name ());
                     application_closed (
                         App () {
                             name = app.get_name (),
                             icon = app.get_icon (),
                             desktop_file = app.get_desktop_file (),
                             pids = win_pids,
-                            xid = app.get_xids ().index(0)
+                            xid = app.get_xids ().index (0)
                         }
                     );
                 }
@@ -107,7 +107,7 @@ namespace Monitor {
                                 icon = bamf_app.get_icon (),
                                 desktop_file = bamf_app.get_desktop_file (),
                                 pids = win_pids,
-                                xid = bamf_app.get_xids ().index(0)
+                                xid = bamf_app.get_xids ().index (0)
                             };
                 }
             }
@@ -116,21 +116,21 @@ namespace Monitor {
 
         private bool is_main_window (Bamf.View view) {
             var window_type = ((Bamf.Window)view).get_window_type ();
-            debug ("Window type: %d, Is transient: %d", window_type, (int)is_transient(view));
+            debug ("Window type: %d, Is transient: %d", window_type, (int)is_transient (view));
             return (window_type == Bamf.WindowType.NORMAL ||
-                    window_type == Bamf.WindowType.DOCK) && !is_transient(view);
+                    window_type == Bamf.WindowType.DOCK) && !is_transient (view);
         }
 
         // if window is transient add its xid to array and return true
         private bool is_transient (Bamf.View view) {
-            if(transient_xids.size > 0 && transient_xids.contains(((Bamf.Window)view).get_xid())) {
+            if (transient_xids.size > 0 && transient_xids.contains (((Bamf.Window)view).get_xid ())) {
                 return true;
             }
             if (((Bamf.Window)view).get_transient () != null) {
-                transient_xids.add (((Bamf.Window)view).get_xid());
+                transient_xids.add (((Bamf.Window)view).get_xid ());
                 return true;
             }
             return false;
         }
-	}
+    }
 }

--- a/src/Managers/Process.vala
+++ b/src/Managers/Process.vala
@@ -1,5 +1,3 @@
-
-
 namespace Monitor {
 
     public class Process {
@@ -118,7 +116,7 @@ namespace Monitor {
                 mem_usage = (proc_mem.resident - proc_mem.share) / 1024; // in KiB
 
                 if (Gdk.Display.get_default () is Gdk.X11.Display) {
-                    Wnck.ResourceUsage resu = Wnck.ResourceUsage.pid_read (Gdk.Display.get_default(), pid);
+                    Wnck.ResourceUsage resu = Wnck.ResourceUsage.pid_read (Gdk.Display.get_default (), pid);
                     mem_usage += (resu.total_bytes_estimate / 1024);
                 }
             } catch (Error e) {

--- a/src/Models/GenericModel.vala
+++ b/src/Models/GenericModel.vala
@@ -20,9 +20,9 @@ namespace Monitor {
                 typeof (int64),
                 typeof (int),
             };
-            set_column_types(types);
+            set_column_types (types);
 
-            helper = new ModelHelper(this);
+            helper = new ModelHelper (this);
 
             process_manager = ProcessManager.get_default ();
             process_manager.process_added.connect ((process) => add_process (process));
@@ -33,8 +33,8 @@ namespace Monitor {
             app_manager.application_opened.connect ((app) => { add_app (app); });
             app_manager.application_closed.connect ((app) => { remove_app (app); });
 
-            Idle.add (() => { add_running_apps (); return false; } );
-            Idle.add (() => { add_running_processes (); return false; } );
+            Idle.add (() => { add_running_apps (); return false; });
+            Idle.add (() => { add_running_processes (); return false; });
 
             add_background_apps_row ();
         }
@@ -171,37 +171,37 @@ namespace Monitor {
                 Value pid_value;
                 get_value (child_iter, Column.PID, out pid_value);
                 pid_value_prev = pid_value;
-                debug( "reparent %d", pid_value.get_int ());
+                debug ("reparent %d", pid_value.get_int ());
 
                 add_process_to_row (background_apps_iter, pid_value.get_int ());
             }
         }
 
         private void remove_process (int pid) {
-            debug ("remove process %d from model".printf(pid));
+            debug ("remove process %d from model".printf (pid));
             // if process rows has pid
             if (process_rows.has_key (pid)) {
                 var row = process_rows.get (pid);
                 Gtk.TreeIter iter = row.iter;
-    
+
                 debug ("remove process: user_data %d, stamp %d", (int) iter.user_data, iter.stamp);
-                
+
                 Value pid_value;
                 get_value (iter, Column.PID, out pid_value);
-    
+
                 // Column.NAME, for example returns (null)
                 // Column.PID return 0
-                
-                debug("removing %d", pid_value.get_int());
-    
+
+                debug ("removing %d", pid_value.get_int ());
+
                 // sometimes iter has null values
                 // this potentially should prevent segfaults
-                if (pid_value.get_int() != 0) {
+                if (pid_value.get_int () != 0) {
                     reparent (ref iter);
                     // remove row from model
                     remove (ref iter);
                 }
-    
+
                 // remove row from row cache
                 process_rows.unset (pid);
             }
@@ -300,7 +300,7 @@ namespace Monitor {
             if (pid > 0) {
                 var process = process_manager.get_process (pid);
                 process.kill ();
-                info ("Kill:%d",process.pid);
+                info ("Kill:%d", process.pid);
             }
         }
 
@@ -308,7 +308,7 @@ namespace Monitor {
             if (pid > 0) {
                 var process = process_manager.get_process (pid);
                 process.end ();
-                info ("End:%d",process.pid);
+                info ("End:%d", process.pid);
             }
         }
     }

--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -7,7 +7,7 @@ namespace Monitor {
 
         private static bool start_in_background = false;
         private static bool status_background = false;
-        private const GLib.OptionEntry[] cmd_options = {
+        private const GLib.OptionEntry[] CMD_OPTIONS = {
         // --start-in-background
             { "start-in-background", 'b', 0, OptionArg.NONE, ref start_in_background, "Start in background with wingpanel indicator", null },
             // list terminator
@@ -66,7 +66,7 @@ namespace Monitor {
             try {
                 var opt_context = new OptionContext ("");
                 opt_context.set_help_enabled (true);
-                opt_context.add_main_entries (cmd_options, null);
+                opt_context.add_main_entries (CMD_OPTIONS, null);
                 opt_context.parse (ref args);
             } catch (OptionError e) {
                 print ("Error: %s\n", e.message);

--- a/src/Resources/CPU.vala
+++ b/src/Resources/CPU.vala
@@ -1,36 +1,36 @@
-    public class Monitor.CPU : Object {
-        private float last_used;
-        private float last_total;
-        private float load;
+public class Monitor.CPU : Object {
+    private float last_used;
+    private float last_total;
+    private float load;
 
-        GTop.Cpu? cpu;
+    GTop.Cpu? cpu;
 
-        public int percentage {
-            get {
-                update ();
-                return (int) (Math.round(load * 100));
-            }
-        }
-        construct {
-            last_used = 0;
-            last_total = 0;
-        }
-
-        public CPU () { }
-
-        private void update () {
-            GTop.get_cpu (out cpu);
-
-            var used = (float) (cpu.user + cpu.sys + cpu.nice + cpu.irq + cpu.softirq);
-            var idle = (float) (cpu.idle + cpu.iowait);
-            var total = used + idle;
-
-            var diff_used = used - last_used;
-            var diff_total = total - last_total;
-
-            load = diff_used.abs () / diff_total.abs ();
-
-            last_used = used;
-            last_total = total;
+    public int percentage {
+        get {
+            update ();
+            return (int) (Math.round (load * 100));
         }
     }
+    construct {
+        last_used = 0;
+        last_total = 0;
+    }
+
+    public CPU () { }
+
+    private void update () {
+        GTop.get_cpu (out cpu);
+
+        var used = (float) (cpu.user + cpu.sys + cpu.nice + cpu.irq + cpu.softirq);
+        var idle = (float) (cpu.idle + cpu.iowait);
+        var total = used + idle;
+
+        var diff_used = used - last_used;
+        var diff_total = total - last_total;
+
+        load = diff_used.abs () / diff_total.abs ();
+
+        last_used = used;
+        last_total = total;
+    }
+}

--- a/src/Resources/Core.vala
+++ b/src/Resources/Core.vala
@@ -1,6 +1,6 @@
 namespace Monitor {
     //from Monilet
-    public class Core  : GLib.Object {
+    public class Core : GLib.Object {
         private float last_total;
         private float last_used;
 
@@ -11,23 +11,21 @@ namespace Monitor {
             get { update_percentage_used (); return _percentage_used; }
         }
 
-        public Core (int number){
-            Object (number : number);
+        public Core (int number) {
+            Object (number: number);
             last_used = 0;
             last_total = 0;
         }
 
-        private void update_percentage_used (){
+        private void update_percentage_used () {
             GTop.Cpu cpu;
             GTop.get_cpu (out cpu);
 
-    		var used =  cpu.xcpu_user[number] +
-    		            cpu.xcpu_nice[number] +
-    		            cpu.xcpu_sys[number];
+            var used = cpu.xcpu_user[number] + cpu.xcpu_nice[number] + cpu.xcpu_sys[number];
 
-    		var difference_used = (float) used - last_used;
-    		var difference_total = (float) cpu.xcpu_total[number] - last_total;
-    		var pre_percentage = difference_used.abs () / difference_total.abs ();  // calculate the pre percentage
+            var difference_used = (float) used - last_used;
+            var difference_total = (float) cpu.xcpu_total[number] - last_total;
+            var pre_percentage = difference_used.abs () / difference_total.abs ();  // calculate the pre percentage
 
             _percentage_used = pre_percentage * 100;
 

--- a/src/Resources/Memory.vala
+++ b/src/Resources/Memory.vala
@@ -9,7 +9,7 @@ namespace Monitor {
         public int percentage {
             get {
                 update ();
-                return (int) (Math.round((used / total) * 100));
+                return (int) (Math.round ((used / total) * 100));
             }
         }
 
@@ -22,7 +22,7 @@ namespace Monitor {
 
         private void update () {
             GTop.get_mem (out mem);
-    		total = (double) (mem.total / 1024 / 1024) / 1000;
+            total = (double) (mem.total / 1024 / 1024) / 1000;
             used = (double) (mem.user / 1024 / 1024) / 1000;
         }
     }

--- a/src/Services/Shortcuts.vala
+++ b/src/Services/Shortcuts.vala
@@ -10,12 +10,12 @@ namespace Monitor {
             handled = false;
             char typed = e.str[0];
 
-            if (typed.isalnum () && !window.headerbar.search.is_focus ) {
+            if (typed.isalnum () && !window.headerbar.search.is_focus) {
                 window.headerbar.search.activate_entry (e.str);
                 handled = true;
             }
 
-            if((e.state & Gdk.ModifierType.CONTROL_MASK) != 0) {
+            if ((e.state & Gdk.ModifierType.CONTROL_MASK) != 0) {
                 switch (e.keyval) {
                     case Gdk.Key.f:
                         window.headerbar.search.activate_entry ();

--- a/src/Widgets/OverallView.vala
+++ b/src/Widgets/OverallView.vala
@@ -1,4 +1,3 @@
-
 namespace Monitor {
 
     public class OverallView : Gtk.TreeView {
@@ -11,10 +10,9 @@ namespace Monitor {
 
         const string NO_DATA = "\u2014";
 
-
         public OverallView (GenericModel model) {
             this.model = model;
-            regex = /(?i:^.*\.(xpm|png)$)/;
+            regex = /(?i:^.*\.(xpm|png)$)/; //vala-lint=space-before-paren
 
             // setup name column
             name_column = new Gtk.TreeViewColumn ();
@@ -73,6 +71,7 @@ namespace Monitor {
 
             set_model (model);
         }
+
         public void icon_cell_layout (Gtk.CellLayout cell_layout, Gtk.CellRenderer icon_cell, Gtk.TreeModel model, Gtk.TreeIter iter) {
             Value icon_name;
             model.get_value (iter, Column.ICON, out icon_name);
@@ -89,6 +88,7 @@ namespace Monitor {
                 (icon_cell as Gtk.CellRendererPixbuf).icon_name = (string) icon_name;
             }
         }
+
         public void cpu_usage_cell_layout (Gtk.CellLayout cell_layout, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter) {
             // grab the value that was store in the model and convert it down to a usable format
             Value cpu_usage_value;
@@ -155,9 +155,9 @@ namespace Monitor {
             Gtk.TreeIter iter;
             Gtk.TreeModel model;
             int pid = 0;
-            var selection = this.get_selection ().get_selected_rows(out model).nth_data(0);
-		    model.get_iter (out iter, selection);
-		    model.get (iter, Column.PID, out pid);
+            var selection = this.get_selection ().get_selected_rows (out model).nth_data (0);
+            model.get_iter (out iter, selection);
+            model.get (iter, Column.PID, out pid);
             return pid;
         }
 
@@ -165,14 +165,14 @@ namespace Monitor {
 
         public void expanded () {
             Gtk.TreeModel model;
-            var selection = this.get_selection ().get_selected_rows(out model).nth_data(0);
-		    this.expand_row (selection, false);
+            var selection = this.get_selection ().get_selected_rows (out model).nth_data (0);
+            this.expand_row (selection, false);
         }
 
         public void collapse () {
             Gtk.TreeModel model;
-            var selection = this.get_selection ().get_selected_rows(out model).nth_data(0);
-		    this.collapse_row (selection);
+            var selection = this.get_selection ().get_selected_rows (out model).nth_data (0);
+            this.collapse_row (selection);
         }
 
         public void kill_process () {

--- a/src/Widgets/Search.vala
+++ b/src/Widgets/Search.vala
@@ -1,6 +1,6 @@
 namespace Monitor {
 
-    public class Search :  Gtk.SearchEntry {
+    public class Search : Gtk.SearchEntry {
         public MainWindow window { get; construct; }
         private Gtk.TreeModelFilter filter_model;
         private OverallView process_view;
@@ -16,7 +16,7 @@ namespace Monitor {
 
             filter_model = new Gtk.TreeModelFilter (window.generic_model, null);
             connect_signal ();
-            filter_model.set_visible_func(filter_func);
+            filter_model.set_visible_func (filter_func);
             process_view.set_model (filter_model);
 
             var sort_model = new Gtk.TreeModelSort.with_model (filter_model);
@@ -50,17 +50,17 @@ namespace Monitor {
             int pid_haystack;
             bool found = false;
             var needle = this.text;
-            if ( needle.length == 0 ) {
+            if (needle.length == 0) {
                 return true;
             }
 
-            model.get( iter, Column.NAME, out name_haystack, -1 );
-            model.get( iter, Column.PID, out pid_haystack, -1 );
+            model.get (iter, Column.NAME, out name_haystack, -1);
+            model.get (iter, Column.PID, out pid_haystack, -1);
 
             // sometimes name_haystack is null
             if (name_haystack != null) {
-                bool name_found = name_haystack.casefold().contains(needle.casefold()) || false;
-                bool pid_found = pid_haystack.to_string().casefold().contains(needle.casefold()) || false;
+                bool name_found = name_haystack.casefold ().contains (needle.casefold ()) || false;
+                bool pid_found = pid_haystack.to_string ().casefold ().contains (needle.casefold ()) || false;
                 found = name_found || pid_found;
             }
 

--- a/src/Widgets/Statusbar/Statusbar.vala
+++ b/src/Widgets/Statusbar/Statusbar.vala
@@ -6,7 +6,7 @@ public class Monitor.Statusbar : Gtk.ActionBar {
     construct {
         var cpu_icon = new Gtk.Image.from_icon_name ("cpu-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
         cpu_icon.tooltip_text = _ ("CPU");
-        
+
         var ram_icon = new Gtk.Image.from_icon_name ("ram-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
         ram_icon.tooltip_text = _ ("Memory");
 


### PR DESCRIPTION
I've *linted* codes using [vala-lint](https://github.com/vala-lang/vala-lint). Adding missing whitespaces/newlines or removing extra ones, using 4 spaces instead of tabs for indentations, etc.

I've added a mark to disable vala-lint checks explicitly [here](https://github.com/ryonakano/monitor/blob/8e29dfde29fa7a5cd8d1f3e06324f820177edc7c/src/Widgets/OverallView.vala#L15) because this line contains regex and that's not the case to lint there. If you don't like to add this flag, I'll remove it. :wink:

If you'd like to review without any whitespace changes, try "Hide whitespace changes" mode in GitHub.
