### PR TITLE
Require libdazzle 3.30 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 * libgtk-3-dev
 * libgranite-dev (>= 5.2.0)
 * libbamf3-dev
+* libdazzle-1.0 (>= 3.30)
 * libwnck-3-dev
 * libgtop2-dev
 * libwingpanel-2.0-dev

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends: meson,
                valac (>= 0.26),
                libgranite-dev (>= 5.2.0),
                libbamf3-dev,
+               libdazzle-1.0 (>= 3.30),
                libwnck-3-dev,
                libgtop2-dev,
                libwingpanel-2.0-dev

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,7 @@ gtop = dependency('libgtop-2.0')
 wnck = dependency('libwnck-3.0')
 wingpanel = dependency('wingpanel-2.0')
 gdk_x11 = dependency('gdk-x11-3.0')
-dazzle = dependency('libdazzle-1.0')
+dazzle = dependency('libdazzle-1.0', version: '>= 3.30')
 
 config_data = configuration_data()
 config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())


### PR DESCRIPTION
I saw this error on a "vanilla" elementary OS Hera and found that this static method available in libdazzle 3.30 or later:

```
../src/Models/GraphModel.vala:16.9-16.22: error: The name `iter_set_value' does not exist in the context of `Monitor.GraphModel.update'
        iter_set_value (iter, 0, percentage);
        ^^^^^^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
```
