### PR TITLE
deb-packaging: Ignore dh_auto_test

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,3 +11,5 @@
 
 %:
 	dh $@
+
+override_dh_auto_test:


### PR DESCRIPTION
Running `dh_auto_test` seems to try to run tests which need GUI on Houston (which is CUI), and [causes the CI fails](https://travis-ci.org/github/stsdc/monitor/builds/673311769#L3484-L3490).

According to https://www.debian.org/doc/manuals/maint-guide/dreq.en.html:

> If the Makefile in the source for gentoo contains a test target which you do not want to run for the  Debian package building process, you can use an empty override_dh_auto_test target to skip it.
> ```
> override_dh_auto_test:
> ```

(But I'm not sure if this is the right solution because we'll no longer run any tests on build… :thinking:)
