### PR TITLE
Indicator: Cleanup and fix deprecations

### DIFF
--- a/src/Indicator/Indicator.vala
+++ b/src/Indicator/Indicator.vala
@@ -45,66 +45,33 @@ public class Monitor.Indicator : Wingpanel.Indicator {
 
     }
 
-    /* Constructor */
     public Indicator () {
-        /* Some information about the indicator */
-        Object (code_name : "monitor", /* Unique name */
-                display_name : _("Monitor Indicator"), /* Localised name */
-                description: _("Show system resources")); /* Short description */
+        Object (code_name: "monitor");
     }
 
-    /* This method is called to get the widget that is displayed in the top bar */
     public override Gtk.Widget get_display_widget () {
         return display_widget;
     }
 
-    /* This method is called to get the widget that is displayed in the popover */
     public override Gtk.Widget? get_widget () {
         return popover_widget;
     }
 
-    /* This method is called when the indicator popover opened */
     public override void opened () {
-        /* Use this method to get some extra information while displaying the indicator */
     }
 
-    /* This method is called when the indicator popover closed */
     public override void closed () {
     }
-
-    /* Method to hide the indicator for a short time */
-    // private void hide_me () {
-    //     /* Hide the indicator */
-    //     this.visible = false;
-    //
-    //     /* Show the indicator after two seconds */
-    //     Timeout.add (2000, () => {
-    //         /* Show it */
-    //         this.visible = true;
-    //
-    //         /* Don't run this timer in an endless loop */
-    //         return false;
-    //     });
-    // }
 }
 
-/*
- * This method is called once after your plugin has been loaded.
- * Create and return your indicator here if it should be displayed on the current server.
- */
 public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
-    /* A small message for debugging reasons */
     debug ("Activating Monitor Indicator");
 
-    /* Check which server has loaded the plugin */
     if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {
         /* We want to display our monitor indicator only in the "normal" session, not on the login screen, so stop here! */
         return null;
     }
 
-    /* Create the indicator */
     var indicator = new Monitor.Indicator ();
-
-    /* Return the newly created indicator */
     return indicator;
 }


### PR DESCRIPTION
## Changes Summary
- Remove redundant comments from `sample-indicator`
- `display_name` & `description` were deprecated in https://github.com/elementary/wingpanel/commit/86098c2059e7fa6af82f888f755aeec31d00fd31
