### PR TITLE
Fix paths for translated Vala files and remove missing modules

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -9,3 +9,6 @@ src/Managers/AppManager.vala
 src/Managers/ProcessManager.vala
 src/Managers/Process.vala
 src/Services/Shortcuts.vala
+src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala
+src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala
+src/Views/ProcessView/ProcessInfoView/Preventor.vala

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,12 +2,10 @@ src/Monitor.vala
 src/MainWindow.vala
 src/Indicator/Widgets/PopoverWidget.vala
 src/Indicator/Indicator.vala
-src/Widgets/Headerbar.vala
-src/Widgets/OverallView.vala
-src/Widgets/Search.vala
+src/Widgets/Headerbar/Headerbar.vala
+src/Widgets/Headerbar/Search.vala
 src/Widgets/Statusbar/Statusbar.vala
 src/Managers/AppManager.vala
 src/Managers/ProcessManager.vala
 src/Managers/Process.vala
-src/Models/GenericModel.vala
 src/Services/Shortcuts.vala

--- a/src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala
+++ b/src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala
@@ -14,7 +14,7 @@ public class Monitor.CPUProcessTreeView : Gtk.TreeView {
 
         // setup name column
         name_column = new Gtk.TreeViewColumn ();
-        name_column.title = _ ("Process Name");
+        name_column.title = _("Process Name");
         name_column.expand = true;
         name_column.min_width = 250;
         name_column.set_sort_column_id (Column.NAME);


### PR DESCRIPTION
Hi,

`GenericModel.vala` does no longer exist that's why I have removed it.

`Headerbar.vala` and `Search.vala` were being pointed the wrong paths out. Because of this, it was not possible to generate PO file for a new translation.

@stsdc PO files are also supposed be updated. Many thanks!