### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Views/ProcessView/ProcessInfoView/Chart.vala
+++ b/src/Views/ProcessView/ProcessInfoView/Chart.vala
@@ -46,7 +46,7 @@ public class Monitor.Chart : Gtk.Box {
         chart.add_value (serie, value);
     }
 
-    public void set_data (Gee.ArrayList<double?> history) {
+    public new void set_data (Gee.ArrayList<double?> history) {
         var refresh_rate_is_ms = 2000; //your own refresh rate in milliseconds      
         chart.add_unaware_timestamp_collection(serie, history, refresh_rate_is_ms);
     }

--- a/src/Views/ProcessView/ProcessInfoView/Preventor.vala
+++ b/src/Views/ProcessView/ProcessInfoView/Preventor.vala
@@ -5,7 +5,7 @@ public class Monitor.Preventor : Gtk.Stack {
     private Gtk.Button confirm_button;
     private Gtk.Button deny_button;
 
-    private Gtk.Widget child;
+    private Gtk.Widget child_widget;
 
     public signal void confirmed (bool is_confirmed);
 
@@ -33,19 +33,19 @@ public class Monitor.Preventor : Gtk.Stack {
     }
 
     public Preventor (Gtk.Widget _child, string name) {
-        child = _child;
-        add_named (child, name);
+        child_widget = _child;
+        add_named (child_widget, name);
         add_named (preventive_action_bar, "preventive_action_bar");
 
         deny_button.clicked.connect (() => {
             set_transition_type(Gtk.StackTransitionType.SLIDE_UP);
-            set_visible_child (child);
+            set_visible_child (child_widget);
             confirmed(false);
         });
 
         confirm_button.clicked.connect(() => {
             set_transition_type(Gtk.StackTransitionType.SLIDE_UP);
-            set_visible_child (child);
+            set_visible_child (child_widget);
             confirmed(true);
         });
     }

--- a/src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala
+++ b/src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala
@@ -22,7 +22,6 @@ public class Monitor.ProcessInfoView : Gtk.Box {
         }
     }
     public string ? icon_name;
-    private Gtk.ScrolledWindow command_wrapper;
 
     private Gtk.InfoBar permission_error_infobar;
     private Gtk.Label permission_error_label;
@@ -31,14 +30,8 @@ public class Monitor.ProcessInfoView : Gtk.Box {
     private ProcessInfoIOStats process_info_io_stats;
     private ProcessInfoCPURAM process_info_cpu_ram;
 
-    
-    private Regex ? regex;
-    private Gtk.Grid grid;
-
     private Gtk.Button end_process_button;
     private Gtk.Button kill_process_button;
-
-    private Preventor preventor;
 
     public ProcessInfoView () {
         orientation = Gtk.Orientation.VERTICAL;

--- a/src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala
+++ b/src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala
@@ -82,12 +82,12 @@ public class Monitor.CPUProcessTreeView : Gtk.TreeView {
 
             try {
                 Gdk.Pixbuf icon = new Gdk.Pixbuf.from_file_at_size (path, 16, -1);
-                (icon_cell as Gtk.CellRendererPixbuf).pixbuf = icon;
+                ((Gtk.CellRendererPixbuf)icon_cell).pixbuf = icon;
             } catch (Error e) {
                 warning (e.message);
             }
         } else {
-            (icon_cell as Gtk.CellRendererPixbuf).icon_name = path;
+            ((Gtk.CellRendererPixbuf)icon_cell).icon_name = path;
         }
     }
 
@@ -99,9 +99,9 @@ public class Monitor.CPUProcessTreeView : Gtk.TreeView {
 
         // format the double into a string
         if (cpu_usage < 0.0)
-            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
+            ((Gtk.CellRendererText)cell).text = Utils.NO_DATA;
         else
-            (cell as Gtk.CellRendererText).text = "%.0f%%".printf (cpu_usage);
+            ((Gtk.CellRendererText)cell).text = "%.0f%%".printf (cpu_usage);
     }
 
     public void memory_usage_cell_layout (Gtk.CellLayout cell_layout, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter) {
@@ -126,9 +126,9 @@ public class Monitor.CPUProcessTreeView : Gtk.TreeView {
 
         // format the double into a string
         if (memory_usage == 0)
-            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
+            ((Gtk.CellRendererText)cell).text = Utils.NO_DATA;
         else
-            (cell as Gtk.CellRendererText).text = "%.1f %s".printf (memory_usage_double, units);
+            ((Gtk.CellRendererText)cell).text = "%.1f %s".printf (memory_usage_double, units);
     }
 
     private void pid_cell_layout (Gtk.CellLayout cell_layout, Gtk.CellRenderer cell, Gtk.TreeModel model, Gtk.TreeIter iter) {
@@ -137,7 +137,7 @@ public class Monitor.CPUProcessTreeView : Gtk.TreeView {
         int pid = pid_value.get_int ();
         // format the double into a string
         if (pid == 0) {
-            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
+            ((Gtk.CellRendererText)cell).text = Utils.NO_DATA;
         }
     }
 


### PR DESCRIPTION
Fixes these warnings shown on compile with valac 0.48.7:

```
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:85.17-85.60: warning: Access to possible `null'. Perform a check or use an unsafe cast.
                (icon_cell as Gtk.CellRendererPixbuf).pixbuf = icon;
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:90.13-90.59: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (icon_cell as Gtk.CellRendererPixbuf).icon_name = path;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:102.13-102.47: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:104.13-104.47: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (cell as Gtk.CellRendererText).text = "%.0f%%".printf (cpu_usage);
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:129.13-129.47: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:131.13-131.47: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (cell as Gtk.CellRendererText).text = "%.1f %s".printf (memory_usage_double, units);
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:140.13-140.47: warning: Access to possible `null'. Perform a check or use an unsafe cast.
            (cell as Gtk.CellRendererText).text = Utils.NO_DATA;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/Chart.vala:49.5-49.24: warning: Monitor.Chart.set_data hides inherited method `GLib.Object.set_data'. Use the `new' keyword if hiding was intentional
    public void set_data (Gee.ArrayList<double?> history) {
    ^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/Preventor.vala:8.5-8.28: warning: Monitor.Preventor.child hides inherited field `Gtk.Container.child'. Use the `new' keyword if hiding was intentional
    private Gtk.Widget child;
    ^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:25.5-25.46: warning: field `Monitor.ProcessInfoView.command_wrapper' never used
    private Gtk.ScrolledWindow command_wrapper;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:35.5-35.25: warning: field `Monitor.ProcessInfoView.regex' never used
    private Regex ? regex;
    ^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:36.5-36.25: warning: field `Monitor.ProcessInfoView.grid' never used
    private Gtk.Grid grid;
    ^^^^^^^^^^^^^^^^^^^^^
../src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:41.5-41.31: warning: field `Monitor.ProcessInfoView.preventor' never used
    private Preventor preventor;
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Compilation succeeded - 13 warning(s)
```
