### PR TITLE
Fix compile warnings

### DIFF
--- a/src/Resources/TemperatureSensor.vala
+++ b/src/Resources/TemperatureSensor.vala
@@ -26,45 +26,49 @@ class TemperatureSensor : Object {
 
 
     private void traverser () {
-        Dir hwmon_dir = Dir.open (hwmon_path, 0);
+        try {
+            Dir hwmon_dir = Dir.open (hwmon_path, 0);
 
-        string ? hwmonx = null;
-        while ((hwmonx = hwmon_dir.read_name ()) != null) {
-            string hwmonx_name = Path.build_filename (hwmon_path, hwmonx, "name");
-            string sensor_location = open_file (hwmonx_name);
+            string ? hwmonx = null;
+            while ((hwmonx = hwmon_dir.read_name ()) != null) {
+                string hwmonx_name = Path.build_filename (hwmon_path, hwmonx, "name");
+                string sensor_location = open_file (hwmonx_name);
 
-            if (sensor_location == "coretemp" || sensor_location == "k10temp") {
-                debug ("Found temp. sensor: %s", sensor_location);
+                if (sensor_location == "coretemp" || sensor_location == "k10temp") {
+                    debug ("Found temp. sensor: %s", sensor_location);
 
-                Dir hwmonx_dir = Dir.open (Path.build_filename (hwmon_path, hwmonx), 0);
-                string ? hwmonx_prop = null;
-                while ((hwmonx_prop = hwmonx_dir.read_name ()) != null) {
-                    //  debug (open_file (hwmonx_name));
+                    Dir hwmonx_dir = Dir.open (Path.build_filename (hwmon_path, hwmonx), 0);
+                    string ? hwmonx_prop = null;
+                    while ((hwmonx_prop = hwmonx_dir.read_name ()) != null) {
+                        //  debug (open_file (hwmonx_name));
 
-                    if (hwmonx_prop.contains ("temp")) {
-                        // AMD stuff
-                        // Tdie contains true temperature value, while Tctl contains value for fans
-                        // Tctl = Tdie + offset in some processors
-                        if ("Tdie" == open_file (Path.build_filename (hwmon_path, hwmonx, hwmonx_prop))) {
-                            string tempx_input = "temp%c_input".printf(hwmonx_prop[4]);
-                            cpu_temp_paths.add (Path.build_filename (hwmon_path, hwmonx, tempx_input));
-                            
-                            debug (open_file (cpu_temp_paths[0]));
+                        if (hwmonx_prop.contains ("temp")) {
+                            // AMD stuff
+                            // Tdie contains true temperature value, while Tctl contains value for fans
+                            // Tctl = Tdie + offset in some processors
+                            if ("Tdie" == open_file (Path.build_filename (hwmon_path, hwmonx, hwmonx_prop))) {
+                                string tempx_input = "temp%c_input".printf(hwmonx_prop[4]);
+                                cpu_temp_paths.add (Path.build_filename (hwmon_path, hwmonx, tempx_input));
+                                
+                                debug (open_file (cpu_temp_paths[0]));
 
-                        // Intel stuff
-                        // Intel reports per core
-                        } else if (open_file (Path.build_filename (hwmon_path, hwmonx, hwmonx_prop)).contains ("Core")) {
-                            string tempx_input = "temp%c_input".printf(hwmonx_prop[4]);
-                            cpu_temp_paths.add (Path.build_filename (hwmon_path, hwmonx, tempx_input));
-                            debug (open_file (cpu_temp_paths[0]));
+                            // Intel stuff
+                            // Intel reports per core
+                            } else if (open_file (Path.build_filename (hwmon_path, hwmonx, hwmonx_prop)).contains ("Core")) {
+                                string tempx_input = "temp%c_input".printf(hwmonx_prop[4]);
+                                cpu_temp_paths.add (Path.build_filename (hwmon_path, hwmonx, tempx_input));
+                                debug (open_file (cpu_temp_paths[0]));
+                            }
                         }
                     }
+                } else if (sensor_location == "amdgpu" ) {
+                    debug ("Found temp. sensor: %s", sensor_location);
+                } else {
+                    debug ("Found temp. sensor: %s", sensor_location);
                 }
-            } else if (sensor_location == "amdgpu" ) {
-                debug ("Found temp. sensor: %s", sensor_location);
-            } else {
-                debug ("Found temp. sensor: %s", sensor_location);
             }
+        } catch (FileError e) {
+            warning (@"Could not open dir: %s", e.message);
         }
     }
 
@@ -75,7 +79,6 @@ class TemperatureSensor : Object {
             return read.replace ("\n","");
         } catch (FileError e) {
             error ("%s\n", e.message);
-            return "0";
         }
     }
 }

--- a/src/Views/SystemView/SystemCPUView.vala
+++ b/src/Views/SystemView/SystemCPUView.vala
@@ -9,7 +9,7 @@ public class Monitor.SystemCPUView : Gtk.Box {
     private LabelRoundy cpu_temperature_label;
     private LabelH4 processor_name_label;
 
-    private Gtk.Button view_threads_usage_button;
+    //  private Gtk.Button view_threads_usage_button;
 
     private Gtk.Revealer cpu_threads_revealer;
 
@@ -104,7 +104,7 @@ public class Monitor.SystemCPUView : Gtk.Box {
         smol_charts_container.attach (grid_frequency_info, 0, 0, 1, 1);
         smol_charts_container.attach (grid_temperature_info, 0, 1, 1, 1);
         smol_charts_container.row_spacing = 6;
-        smol_charts_container.margin_left = 6;
+        smol_charts_container.margin_start = 6;
 
         // Thanks Goncalo
         var charts_container = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);


### PR DESCRIPTION
there were 4/5 warnings, I fixed them.
2 of them were because of a needed try/catch
another one was a deprecated margin_left, changed with margin_start
Another one was because of an unreachable code (return)
And the last one was an unused variable, which I commented it out