### PR TITLE
Add Flatpak build dependencies

### DIFF
--- a/com.github.stsdc.monitor.yml
+++ b/com.github.stsdc.monitor.yml
@@ -19,6 +19,54 @@ finish-args:
 # If we had external dependencies that weren't included in our SDK, we would list
 # them here.
 modules:
+  - name: libstartup-notification
+    sources:
+      - type: archive
+        url: http://www.freedesktop.org/software/startup-notification/releases/startup-notification-0.12.tar.gz
+        sha256: 3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a
+
+  - name: libwnck
+    buildsystem: meson
+    config-opts:
+      - '-Dstartup_notification=enabled'
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /bin
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libwnck/3.36/libwnck-3.36.0.tar.xz
+        sha256: bc508150b3ed5d22354b0e6774ad4eee465381ebc0ace45eb0e2d3a4186c925f
+
+  - name: libgtop
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libgtop/2.40/libgtop-2.40.0.tar.xz
+        sha256: 78f3274c0c79c434c03655c1b35edf7b95ec0421430897fb1345a98a265ed2d4
+
+  - name: gnome-common
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/gnome-common/3.18/gnome-common-3.18.0.tar.xz
+        sha256: 22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf
+    cleanup:
+      - '*'
+
+  - name: python3-lxml
+    buildsystem: simple
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/e5/21/a2e4517e3d216f0051687eea3d3317557bde68736f038a3b105ac3809247/lxml-4.6.3.tar.gz
+        sha256: 39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} lxml
+
+  - name: bamf
+    sources:
+      - type: archive
+        url: https://launchpad.net/bamf/0.5/0.5.5/+download/bamf-0.5.5.tar.xz
+        md5: 682269ccdde6f6842cceb3cd636d087e
+
   - name: com.github.stsdc.monitor
     buildsystem: meson
     sources:


### PR DESCRIPTION
I have added the build dependencies for Flatpak, so that it does not fail for a missing module.

Note that the build still fails, but now because it is unable to install a systemd service, which requires root privileges. I don't know how to fix that, but if I find anything, I'll let you know.