### PR TITLE
Change section to one that is allowed by Debian/Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: com.github.stsdc.monitor
 Section: util
 Priority: extra
-Maintainer: Stanisław Dac <stanislaw.dac@gmail.com>
+Maintainer: Kristopher Ives <kristopher.ives@gmail.com>
 Build-Depends: meson,
                appstream,
                debhelper (>= 9),

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: com.github.stsdc.monitor
-Section: system
+Section: util
 Priority: extra
 Maintainer: Stanisław Dac <stanislaw.dac@gmail.com>
 Build-Depends: meson,


### PR DESCRIPTION
> The Debian archive maintainers provide the authoritative list of sections. At present, they are: admin, cli-mono, comm, database, debug, devel, doc, editors, education, electronics, embedded, fonts, games, gnome, gnu-r, gnustep, graphics, hamradio, haskell, httpd, interpreters, introspection, java, javascript, kde, kernel, libdevel, libs, lisp, localization, mail, math, metapackages, misc, net, news, ocaml, oldlibs, otherosfs, perl, php, python, ruby, rust, science, shells, sound, tasks, tex, text, utils, vcs, video, web, x11, xfce, zope. The additional section debian-installer contains special packages used by the installer and is not used for normal Debian packages.

From https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections