### PR TITLE
Update Monitor.Storage to work with vdx (vm) and nvme disks. v2

### DIFF
--- a/src/Resources/Storage.vala
+++ b/src/Resources/Storage.vala
@@ -30,7 +30,8 @@ public class Monitor.Storage : GLib.Object {
 
             while ((line = dis.read_line ()) != null) {
                 string[] reg_split = Regex.split_simple ("[ ]+", line);
-                if (reg_split[1] == "8" && Regex.match_simple ("sd[a-z]{1}$", reg_split[3])) {
+                if ((reg_split[1] == "8" | reg_split[1] == "252" | reg_split[1] == "259") && 
+                Regex.match_simple ("((sd|vd)[a-z]{1}|nvme[0-9]{1}n[0-9]{1})$", reg_split[3])) {
                     sectors_read_new += ulong.parse (reg_split[6]);
                     sectors_write_new += ulong.parse (reg_split[10]);
                 }


### PR DESCRIPTION
Update Monitor.Storage to work with vdx (vm) and nvme disks.

Before:
![before](https://user-images.githubusercontent.com/63053131/137603177-f435706f-13e8-477a-83d0-783f7fa53749.png)

After:
![after](https://user-images.githubusercontent.com/63053131/137603179-30f7d545-8f1b-43a7-9545-10f6a55a715e.png)