### PR TITLE
Fix wingpanel crashing due to the stale gschema key names

### DIFF
--- a/src/Indicator/Indicator.vala
+++ b/src/Indicator/Indicator.vala
@@ -20,8 +20,8 @@ public class Monitor.Indicator : Wingpanel.Indicator {
             display_widget.cpu_widget.visible = settings.get_boolean ("indicator-cpu-state");
             display_widget.memory_widget.visible = settings.get_boolean ("indicator-memory-state");
             display_widget.temperature_widget.visible = settings.get_boolean ("indicator-temperature-state");
-            display_widget.network_up_widget.visible = settings.get_boolean ("indicator-network-up-state");
-            display_widget.network_down_widget.visible = settings.get_boolean ("indicator-network-down-state");
+            display_widget.network_up_widget.visible = settings.get_boolean ("indicator-network-upload-state");
+            display_widget.network_down_widget.visible = settings.get_boolean ("indicator-network-download-state");
 
         });
 

--- a/src/Monitor.vala
+++ b/src/Monitor.vala
@@ -50,11 +50,11 @@ namespace Monitor {
                 if (!MonitorApp.settings.get_boolean ("indicator-temperature-state")) {
                     MonitorApp.settings.set_boolean ("indicator-temperature-state", true);
                 }
-                if (!MonitorApp.settings.get_boolean ("indicator-network-up-state")) {
-                    MonitorApp.settings.set_boolean ("indicator-network-up-state", false);
+                if (!MonitorApp.settings.get_boolean ("indicator-network-upload-state")) {
+                    MonitorApp.settings.set_boolean ("indicator-network-upload-state", false);
                 }
-                if (!MonitorApp.settings.get_boolean ("indicator-network-down-state")) {
-                    MonitorApp.settings.set_boolean ("indicator-network-down-state", false);
+                if (!MonitorApp.settings.get_boolean ("indicator-network-download-state")) {
+                    MonitorApp.settings.set_boolean ("indicator-network-download-state", false);
                 }
 
                 window.hide ();


### PR DESCRIPTION
Follow-up to #267

Now the GSchema keys are renamed but the old name remains and this causes the wingpanel crashing in the latest `dev` branch:

```
ryonakano@ryonakano-pc:~/Projects/monitor$ io.elementary.wingpanel 

(io.elementary.wingpanel:37475): GLib-GObject-WARNING **: 22:04:10.204: invalid (NULL) pointer instance

(io.elementary.wingpanel:37475): GLib-GObject-CRITICAL **: 22:04:10.204: g_signal_connect_object: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed

(io.elementary.wingpanel:37475): libnm-CRITICAL **: 22:04:10.204: ((libnm-core/nm-connection.c:193)): assertion '<dropped>' failed
** Message: 22:04:12.340: DBusService.vala:64: Service registration suceeded

(io.elementary.wingpanel:37475): GLib-GIO-ERROR **: 22:04:15.763: Settings schema 'com.github.stsdc.monitor.settings' does not contain a key named 'indicator-network-up-state'
Trace/breakpoint trap
```

This PR fixes this issue.
