### PR TITLE
docs: Add `libxnvctrl-dev` to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ sudo dnf install com.github.stsdc.monitor
 * libwingpanel-3.0-dev
 * libhandy-1-dev
 * libudisks2-dev
+* libxnvctrl-dev
 * meson
 * sassc
 


### PR DESCRIPTION
Adds a line for `libxnvctrl-dev` to the dependencies on the README.md