### PR TITLE
Re-aligned translatable strings

### DIFF
--- a/po/com.github.stsdc.monitor.pot
+++ b/po/com.github.stsdc.monitor.pot
@@ -253,7 +253,7 @@ msgid "Disabled"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:18
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:20
@@ -261,12 +261,12 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:22
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:26
 #: src/Views/SystemView/SystemGPUView.vala:16
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #. int temperature_index = 0;

--- a/po/de.po
+++ b/po/de.po
@@ -189,7 +189,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -200,12 +200,12 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr ""
+msgid "Frequency"
+msgstr "Frequenz"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr ""
+msgid "Temperature"
+msgstr "Temperatur"
 
 #: src/Views/SystemView/SystemCPUView.vala:96
 #: src/Views/SystemView/SystemMemoryView.vala:37
@@ -227,28 +227,28 @@ msgstr ""
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/es.po
+++ b/po/es.po
@@ -203,7 +203,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -214,11 +214,11 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:96
@@ -241,28 +241,28 @@ msgstr ""
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/fr.po
+++ b/po/fr.po
@@ -201,7 +201,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -212,11 +212,11 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:96
@@ -239,28 +239,28 @@ msgstr ""
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/it.po
+++ b/po/it.po
@@ -205,7 +205,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -216,11 +216,11 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:96
@@ -243,28 +243,28 @@ msgstr ""
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/ja.po
+++ b/po/ja.po
@@ -203,7 +203,7 @@ msgstr "RAM: %.1f%%"
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr "使用率"
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -214,11 +214,11 @@ msgid "Show detailed info"
 msgstr "詳細情報を表示します"
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr "周波数"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr "温度"
 
 #: src/Views/SystemView/SystemCPUView.vala:94
@@ -241,29 +241,29 @@ msgstr "GHz"
 msgid "℃"
 msgstr "℃"
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
-msgstr "合計: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "バッファー"
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
-msgstr "使用済み: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "キャッシュ"
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
-msgstr "共有: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "ロック"
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
-msgstr "バッファー: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "合計"
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
-msgstr "キャッシュ: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "使用済み"
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
-msgstr "ロック: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "共有"
 
 #: src/Views/SystemView/SystemMemoryView.vala:101
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -208,7 +208,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -219,11 +219,11 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:96
@@ -246,28 +246,28 @@ msgstr ""
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/nl.po
+++ b/po/nl.po
@@ -252,21 +252,21 @@ msgid "Disabled"
 msgstr "Uitgeschakeld"
 
 #: src/Views/SystemView/SystemCPUView.vala:18
-msgid "UTILIZATION"
-msgstr "GEBRUIK"
+msgid "Utilization"
+msgstr "Gebruik"
 
 #: src/Views/SystemView/SystemCPUView.vala:20
 msgid "Show detailed info"
 msgstr "Uitgebreide informatie tonen"
 
 #: src/Views/SystemView/SystemCPUView.vala:22
-msgid "FREQUENCY"
-msgstr "FREQUENTIE"
+msgid "Frequency"
+msgstr "Frequentie"
 
 #: src/Views/SystemView/SystemCPUView.vala:26
 #: src/Views/SystemView/SystemGPUView.vala:16
-msgid "TEMPERATURE"
-msgstr "TEMPERATUUR"
+msgid "Temperature"
+msgstr "Temperatuur"
 
 #. int temperature_index = 0;
 #. foreach (var temperature in cpu.paths_temperatures.values) {
@@ -336,29 +336,29 @@ msgstr "L3-cache-omvang:"
 msgid "Address sizes:"
 msgstr "Adresgroottes:"
 
-#: src/Views/SystemView/SystemMemoryView.vala:19
-msgid "Total: "
-msgstr "Totaal: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "Gebufferd"
 
-#: src/Views/SystemView/SystemMemoryView.vala:22
-msgid "Used: "
-msgstr "Gebruikt: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "Gecachet"
 
-#: src/Views/SystemView/SystemMemoryView.vala:25
-msgid "Shared: "
-msgstr "Gedeeld: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "Vergrendeld"
 
-#: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "Buffered: "
-msgstr "Gebufferd: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "Totaal"
 
-#: src/Views/SystemView/SystemMemoryView.vala:31
-msgid "Cached: "
-msgstr "Gecachet: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "Gebruikt"
 
-#: src/Views/SystemView/SystemMemoryView.vala:34
-msgid "Locked: "
-msgstr "Vergrendeld: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "Gedeeld"
 
 #: src/Views/SystemView/SystemMemoryView.vala:64
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -187,7 +187,7 @@ msgstr "RAM: %.1f%%"
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -198,12 +198,12 @@ msgid "Show detailed info"
 msgstr "Pokaż szczegóły"
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr "CZĘSTOTLIWOŚĆ"
+msgid "Frequency"
+msgstr "Częstotliwość"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr "TEMPERATURA"
+msgid "Temperature"
+msgstr "Temperatura"
 
 #: src/Views/SystemView/SystemCPUView.vala:96
 #: src/Views/SystemView/SystemMemoryView.vala:37
@@ -224,28 +224,28 @@ msgstr "GHz"
 msgid "℃"
 msgstr "℃"
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/pt.po
+++ b/po/pt.po
@@ -200,8 +200,8 @@ msgstr "RAM: %.1f%%"
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
-msgstr "UTILIZAÇÃO"
+msgid "Utilization"
+msgstr "Utilização"
 
 #: src/Views/SystemView/SystemCPUView.vala:34
 #: src/Views/SystemView/SystemCPUView.vala:94
@@ -211,12 +211,12 @@ msgid "Show detailed info"
 msgstr "Mostrar informação detalhada"
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr "FREQUÊNCIA"
+msgid "Frequency"
+msgstr "Frequência"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr "TEMPERATURA"
+msgid "Temperature"
+msgstr "Temperatura"
 
 #: src/Views/SystemView/SystemCPUView.vala:96
 #: src/Views/SystemView/SystemMemoryView.vala:37
@@ -238,29 +238,29 @@ msgstr "GHz"
 msgid "℃"
 msgstr "℃"
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
-msgstr "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "Buffered"
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
-msgstr "Utilizado: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "Em cache"
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
-msgstr "Partilhado: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "Bloqueado"
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
-msgstr "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "Total"
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
-msgstr "Em cache: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "Utilizado"
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
-msgstr "Bloqueado: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "Partilhado"
 
 #: src/Views/SystemView/SystemMemoryView.vala:103
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -199,8 +199,8 @@ msgstr "Memorie: %.1f%%"
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
-msgstr "UTILIZARE"
+msgid "Utilization"
+msgstr "Utilizare"
 
 #: src/Views/SystemView/SystemCPUView.vala:34
 #: src/Views/SystemView/SystemCPUView.vala:94
@@ -210,12 +210,12 @@ msgid "Show detailed info"
 msgstr "Arată informații detaliate"
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr "FRECVENȚĂ"
+msgid "Frequency"
+msgstr "Frecvență"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr "TEMPERATURĂ"
+msgid "Temperature"
+msgstr "Temperatură"
 
 #: src/Views/SystemView/SystemCPUView.vala:96
 #: src/Views/SystemView/SystemMemoryView.vala:37
@@ -237,29 +237,29 @@ msgstr "GHz"
 msgid "℃"
 msgstr "℃"
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
-msgstr "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "Buffer"
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
-msgstr "Folosit: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "Cache"
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
-msgstr "Partajat: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "Blocat"
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
-msgstr "Buffer: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "Total"
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
-msgstr "Cache: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "Folosit"
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
-msgstr "Blocat: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "Partajat"
 
 #: src/Views/SystemView/SystemMemoryView.vala:103
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -247,21 +247,21 @@ msgid "Disabled"
 msgstr "Отключен"
 
 #: src/Views/SystemView/SystemCPUView.vala:18
-msgid "UTILIZATION"
-msgstr "ИСПОЛЬЗОВАНИЕ"
+msgid "Utilization"
+msgstr "Использование"
 
 #: src/Views/SystemView/SystemCPUView.vala:20
 msgid "Show detailed info"
 msgstr "Показать подробную информацию"
 
 #: src/Views/SystemView/SystemCPUView.vala:22
-msgid "FREQUENCY"
-msgstr "ЧАСТОТА"
+msgid "Frequency"
+msgstr "Частота"
 
 #: src/Views/SystemView/SystemCPUView.vala:26
 #: src/Views/SystemView/SystemGPUView.vala:16
-msgid "TEMPERATURE"
-msgstr "ТЕМПЕРАТУРА"
+msgid "Temperature"
+msgstr "Температура"
 
 #. int temperature_index = 0;
 #. foreach (var temperature in cpu.paths_temperatures.values) {
@@ -331,29 +331,29 @@ msgstr "Размер L3 кэша:"
 msgid "Address sizes:"
 msgstr "Размеры адресов:"
 
-#: src/Views/SystemView/SystemMemoryView.vala:19
-msgid "Total: "
-msgstr "Всего: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "Буферизовано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:22
-msgid "Used: "
-msgstr "Использовано: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "Кешировано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:25
-msgid "Shared: "
-msgstr "Общая: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "Заблокировано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "Buffered: "
-msgstr "Буферизовано: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "Всего"
 
-#: src/Views/SystemView/SystemMemoryView.vala:31
-msgid "Cached: "
-msgstr "Кешировано: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "Использовано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:34
-msgid "Locked: "
-msgstr "Заблокировано: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "Общая"
 
 #: src/Views/SystemView/SystemMemoryView.vala:64
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -201,7 +201,7 @@ msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
+msgid "Utilization"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:34
@@ -212,11 +212,11 @@ msgid "Show detailed info"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
+msgid "Frequency"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
+msgid "Temperature"
 msgstr ""
 
 #: src/Views/SystemView/SystemCPUView.vala:96
@@ -239,28 +239,28 @@ msgstr "GHz"
 msgid "℃"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
 msgstr ""
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
 msgstr ""
 
 #: src/Views/SystemView/SystemMemoryView.vala:103

--- a/po/uk.po
+++ b/po/uk.po
@@ -199,8 +199,8 @@ msgstr "RAM: %.1f%%"
 
 #: src/Views/SystemView/SystemCPUView.vala:32
 #: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
-msgstr "ВИКОРИСТАННЯ"
+msgid "Utilization"
+msgstr "Використання"
 
 #: src/Views/SystemView/SystemCPUView.vala:34
 #: src/Views/SystemView/SystemCPUView.vala:94
@@ -210,12 +210,12 @@ msgid "Show detailed info"
 msgstr "Показати подробиці"
 
 #: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr "ЧАСТОТА"
+msgid "Frequency"
+msgstr "Частота"
 
 #: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr "ТЕМПЕРАТУРА"
+msgid "Temperature"
+msgstr "Температура"
 
 #: src/Views/SystemView/SystemCPUView.vala:96
 #: src/Views/SystemView/SystemMemoryView.vala:37
@@ -237,29 +237,29 @@ msgstr "ГГц"
 msgid "℃"
 msgstr "℃"
 
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
-msgstr "Загалом: "
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "Буферизовано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
-msgstr "Використано: "
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "Кешовано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
-msgstr "Спільний: "
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "Заблоковано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
-msgstr "Буферизовано: "
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "Загалом"
 
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
-msgstr "Кешовано: "
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "Використано"
 
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
-msgstr "Заблоковано: "
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "Спільний"
 
 #: src/Views/SystemView/SystemMemoryView.vala:103
 #, c-format


### PR DESCRIPTION
I corrected some of the translatable strings for the System View; the original strings in the source code were changed which is why the translations were not picked up properly. I re-aligned all the .po files, keeping existing translations intact if they existed. This also makes it easier for others to translate things that have not been translated yet.