### PR TITLE
Removed duplicate translation definition from ja.po

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -315,10 +315,6 @@ msgstr "バックグラウンドで起動:"
 msgid "Items in indicator:"
 msgstr "インジケーターに表示する項目:"
 
-#: src/Widgets/Headerbar/Headerbar.vala:62
-msgid "Temperature"
-msgstr "温度"
-
 #: src/Widgets/Headerbar/Headerbar.vala:66
 msgid "Network up"
 msgstr "ネットワーク送信"


### PR DESCRIPTION
There was one problem with my last commit; there was a duplicate definition in the `ja.po` file, which I've fixed in this commit. Sorry about that.