### PR TITLE
SystemCPUView: Fix untranslatable text

### DIFF
--- a/src/Views/SystemView/SystemCPUView.vala
+++ b/src/Views/SystemView/SystemCPUView.vala
@@ -158,7 +158,7 @@ public class Monitor.SystemCPUView : Monitor.WidgetResource {
                 row = 0;
             }
         }
-        var threads_label = new Gtk.Label (_("Threads".up ()));
+        var threads_label = new Gtk.Label (_("THREADS"));
         threads_label.get_style_context ().add_class ("small-text");
         grid.attach (threads_label, 0, -1, column, 1);
 


### PR DESCRIPTION
- Fix wrong gettext syntax
- Don't use `up()` for translatable texts (not all languages uses English alphabets, e.g. Japanese or Chinese uses Kanji which can't `up()`