### PR TITLE
Update Japanese translation

### DIFF
--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -1,14 +1,14 @@
 # Japanese translations for extra package.
 # Copyright (C) 2019 THE extra'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the extra package.
-# Ryo Nakano <ryonakaknock3@gmail.com>, 2019.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2019, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-20 11:51+0900\n"
-"PO-Revision-Date: 2019-02-20 11:58+0900\n"
+"POT-Creation-Date: 2022-10-22 19:13+0900\n"
+"PO-Revision-Date: 2022-10-22 20:29+0900\n"
 "Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -16,7 +16,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 2.2.1\n"
 
 #: data/com.github.stsdc.monitor.appdata.xml.in:7
 #: data/com.github.stsdc.monitor.desktop.in:3
@@ -31,21 +30,283 @@ msgstr "プロセスを管理し、システムリソースを監視します"
 msgid "Display usage of system resources, filter and manage processes."
 msgstr "システムリソースの消費量を表示し、プロセスをフィルターし管理します。"
 
-#: data/com.github.stsdc.monitor.appdata.xml.in:22
+#: data/com.github.stsdc.monitor.appdata.xml.in:25
 msgid "Stanisław Dac"
 msgstr "Stanisław Dac"
 
-#: data/com.github.stsdc.monitor.appdata.xml.in:31
+#: data/com.github.stsdc.monitor.appdata.xml.in:33
+msgid "Add info about drives (based on Dirli's code)"
+msgstr "ドライバーに関する情報を表示 (Dirli のコードがベース)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:38
+msgid "Adds dark theme 🌚"
+msgstr "ダークテーマを追加 🌚"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:43
+msgid "Uses Wingpanel v3; New *.deb package maintainer: Kristopher Ives"
+msgstr ""
+"Wingpanel 3にバージョンアップしました。また、Kristopher Ives が *.deb パッ"
+"ケージのメンテナーになりました"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:48
+msgid "🐛 Should fix empty Indicator. Please reboot after installation ⚡️"
+msgstr ""
+"🐛 インジケーターに何も表示されない不具合を修正しました。インストール後に再起"
+"動してください ⚡️"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:54
+msgid "🐛 Try to fix frequent GUI hangs 🥶"
+msgstr "🐛 GUI が頻繁に固まる不具合を修正する試みを行いました 🥶"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:55
+msgid "🇳🇱 Update Dutch translation (@Vistaus)"
+msgstr "🇳🇱 オランダ語翻訳を更新 (@Vistaus)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:56
+msgid "🇵🇹 Update Portuguese translation (@hugok79)"
+msgstr "🇵🇹 ポルトガル語翻訳を更新 (@hugok79)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:57
+msgid "🇷🇴 Add Romanian translation (@tiberiufrat)"
+msgstr "🇷🇴 ルーマニア語翻訳を更新 (@tiberiufrat)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:64
+msgid "Display Storage usage"
+msgstr "ストレージの使用状況を表示"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:65
+msgid "Update Russian translation (@camellan)"
+msgstr "ロシア語翻訳を更新 (@camellan)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:66
+msgid "Update Portuguese translation (@hugok79)"
+msgstr "ポルトガル語翻訳を更新 (@hugok79)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:67
+msgid "Different colours for Upload and Download"
+msgstr "送信と受信を異なる色で表示するように修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:74
+#: data/com.github.stsdc.monitor.appdata.xml.in:86
+msgid "Update Portuguese translation (@rottenpants466)"
+msgstr "ポルトガル語翻訳を更新 (@rottenpants466)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:75
+msgid "Update Dutch translation (@Vistaus)"
+msgstr "オランダ語翻訳を更新 (@Vistaus)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:76
+msgid "Smoother animations (@DevAlien)"
+msgstr "描画がなめらかになるように修正 (@DevAlien)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:77
+msgid "Preselect first entry so that the info panel is always open (@DevAlien)"
+msgstr ""
+"情報パネルが常に表示されるように、プロセス一覧の先頭要素を自動で選択するよう"
+"に修正 (@DevAlien)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:78
+msgid "Show CPU temperature in the Indicator"
+msgstr "CPU 温度をインジケーターに表示するように修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:85
+msgid "Better System Tab"
+msgstr "“システム”タブを改善"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:87
+msgid "Save last opened view (@ryonakano)"
+msgstr "最後に開いたタブを復元するように修正 (@ryonakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:94
+#: data/com.github.stsdc.monitor.appdata.xml.in:157
+msgid "Update Japanese translation (Ryo Nakano)"
+msgstr "日本語翻訳を更新 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:95
+msgid "Disable search entry, when System tab is active"
+msgstr "“システム”タブを表示している場合は検索欄を無効化するように修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:96
+msgid "Add screenshots"
+msgstr "スクリーンショットを追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:103
+msgid "Add System resources tab"
+msgstr "システムリソースを表示するタブを追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:110
+msgid "Added tooltips to process state label (Ryo Nakano)"
+msgstr "プロセスの状態を示すラベルにツールチップを追加 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:111
+msgid "Small bugfix"
+msgstr "軽微なバグ修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:118
+msgid "Fix sorting arrows"
+msgstr "並べ替えを示す矢印アイコンを修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:119
+#: data/com.github.stsdc.monitor.appdata.xml.in:155
+#: data/com.github.stsdc.monitor.appdata.xml.in:169
+msgid "Update Russian translation (camellan)"
+msgstr "ロシア語翻訳を更新 (camellan)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:120
+msgid "Add Turkish translation (Harun Yasar)"
+msgstr "トルコ語翻訳を追加 (Harun Yasar)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:121
+msgid ""
+"Use newest version of live-chart (Laurent Callarec) ← Check his lib for "
+"creating charts, it's amazing!"
+msgstr ""
+"最新バージョンの live-chart に更新 (Laurent Callarec) ← グラフを作るためのラ"
+"イブラリです。ぜひ一度見に行っていただきたいほど素晴らしい！"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:128
+msgid "Detailed process info in sidebar"
+msgstr "サイドバーにプロセスの詳細情報を表示する機能を追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:129
+msgid "CPU frequency in tooltip (Ryo Nakano)"
+msgstr "ツールチップに CPU 使用率を表示するように修正 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:136
+msgid "Bugfix (potential) of crushes and high CPU usage"
+msgstr "クラッシュや CPU 使用率を占有してしまう不具合を部分的に修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:137
+msgid "Update German translation (Carsten Dietrich)"
+msgstr "ドイツ語翻訳を更新 (Carsten Dietrich)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:144
+msgid "Update Portuguese translation (Hugo Carvalho)"
+msgstr "ポルトガル語翻訳を更新 (Hugo Carvalho)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:145
+msgid "Update French translation (Nathan Bonnemains and Skeudwenn)"
+msgstr "フランス語翻訳を更新 (Nathan Bonnemains と Skeudwenn)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:146
+msgid "Fix: Don't show swap percentage when it's not available (Ryo Nakano)"
+msgstr "スワップが使用できない場合は使用率を表示しないように修正 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:153
+msgid "Update Italian translation (Mirko Brombin)"
+msgstr "イタリア語翻訳を更新 (Mirko Brombin)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:154
+msgid "Show swap usage (Ryo Nakano)"
+msgstr "スワップ使用率を表示する機能を追加 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:156
+msgid "Code refactoring (Ryo Nakano)"
+msgstr "コードをリファクタリング (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:164
+msgid "Fix contents of the window are not shown (Ryo Nakano)"
+msgstr "ウィンドウの内容が表示されない不具合を修正 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:165
+msgid ""
+"ix no row is still selected when indicator options are enabled (Ryo Nakano)"
+msgstr ""
+"インジケーター機能が有効になっている場合も、プロセスが選択されない不具合を修"
+"正 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:166
+msgid ""
+"Fix the app crashes by clicking the \"End/Kill Process\" buttons when no "
+"process is selected (Ryo Nakano)"
+msgstr ""
+"プロセスが選択されていない状態で \"プロセスを終了\" ボタンや \"プロセスを強制"
+"終了\" ボタンを押すと、アプリがクラッシュする不具合を修正 (Ryo Nakano)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:167
+msgid "Added buttons to either \"kill\" or \"end\" a process. (Evan Buss)"
+msgstr ""
+"プロセスの“強制終了”と“終了”とで別々のボタンに変更しました。(Evan Buss)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:168
+msgid "Change screenshot to English (Christopher Crouse)"
+msgstr "英語のスクリーンショットに変更 (Christopher Crouse)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:170
+msgid "Check if the default display is a X11 display (Hannes Schulze)"
+msgstr ""
+"デフォルトのディスプレイが X11 かどうかを確認するように修正 (Hannes Schulze)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:171
+msgid "Update Spanish translation (Mario Rodrigo)"
+msgstr "スペイン語翻訳を更新 (Mario Rodrigo)"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:178
+msgid "Add start-in-background option to UI"
+msgstr "“バックグラウンドで起動”オプションを UI に追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:185
+msgid "Add start-in-background command line option"
+msgstr "“バックグラウンドで起動”コマンドラインオプションを追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:186
+msgid "Add Italian and Portuguese translations"
+msgstr "イタリア語とポルトガル語の翻訳を更新"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:187
+msgid "Update Dutch, French and Spanish translations"
+msgstr "オランダ語、フランス語、スペイン語の翻訳を更新"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:188
+msgid "Fix Japanese translation"
+msgstr "日本語翻訳を修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:195
+msgid "Minor bug fix"
+msgstr "軽微なバグ修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:196
+msgid "Make End process button red"
+msgstr "“プロセスを終了”ボタンを赤色に変更"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:197
+msgid "Add Japanese translation"
+msgstr "日本語翻訳を追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:204
 msgid "Add CPU and RAM icons"
 msgstr "CPU と RAM のアイコンを追加"
 
-#: data/com.github.stsdc.monitor.appdata.xml.in:32
-msgid "Update Polish and Russian translation"
-msgstr "ポーランド語とロシア語の翻訳をアップデート"
-
-#: data/com.github.stsdc.monitor.appdata.xml.in:33
+#: data/com.github.stsdc.monitor.appdata.xml.in:205
 msgid "Fix bug, that caused hanging"
-msgstr "フリーズの原因となるバグを修正"
+msgstr "フリーズの原因となっていたバグを修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:206
+msgid "Update Polish and Russian translation"
+msgstr "ポーランド語とロシア語の翻訳を更新"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:213
+msgid "Add Monitor indicator"
+msgstr "専用のインジケーターを追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:214
+msgid "Add missing extra French translations"
+msgstr "メタデータ用のフランス語翻訳を追加"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:215
+msgid ""
+"Fix: if icon missing for the process, icon is taken from previous process"
+msgstr ""
+"プロセスのアイコンが存在しない場合、列の一つ前のプロセスと同じアイコンを表示"
+"していた不具合を修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:216
+msgid "Fix: search erases my input while I'm typing"
+msgstr "検索処理が文字入力と干渉する不具合を修正"
+
+#: data/com.github.stsdc.monitor.appdata.xml.in:217
+msgid "Fix POTFILES"
+msgstr "POTFILES を修正"
 
 #: data/com.github.stsdc.monitor.desktop.in:4
 msgid "System Monitor"
@@ -55,10 +316,8 @@ msgstr "システムモニター"
 msgid "Manage processes and monitor resource usage of the system"
 msgstr "プロセスを管理し、システムリソースの消費量を監視します"
 
-#: data/com.github.stsdc.monitor.desktop.in:8
-msgid "com.github.stsdc.monitor"
-msgstr "com.github.stsdc.monitor"
-
 #: data/com.github.stsdc.monitor.desktop.in:12
 msgid "System monitor;System usage;Task manager;"
-msgstr "System monitor;System usage;Task manager;システムモニター;システム消費量;タスクマネージャー;"
+msgstr ""
+"System monitor;System usage;Task manager;システムモニター;システム消費量;タス"
+"クマネージャー;"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,14 +1,14 @@
 # Japanese translations for com.github.stsdc.monitor package.
 # Copyright (C) 2019 THE com.github.stsdc.monitor'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.stsdc.monitor package.
-# Ryo Nakano <ryonakaknock3@gmail.com>, 2019-2021.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2019-2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.stsdc.monitor\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-28 15:21+0900\n"
-"PO-Revision-Date: 2021-09-28 15:27+0900\n"
+"POT-Creation-Date: 2022-10-22 19:13+0900\n"
+"PO-Revision-Date: 2022-10-22 19:33+0900\n"
 "Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -17,11 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/MainWindow.vala:34
+#: src/MainWindow.vala:26 src/Widgets/Headerbar/Headerbar.vala:14
+msgid "Monitor"
+msgstr "モニター"
+
+#: src/MainWindow.vala:37
 msgid "Processes"
 msgstr "プロセス"
 
-#: src/MainWindow.vala:35
+#: src/MainWindow.vala:38
 msgid "System"
 msgstr "システム"
 
@@ -53,7 +57,7 @@ msgstr "MiB"
 
 #: src/Utils.vala:92
 #: src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:128
-#: src/Widgets/Statusbar/Statusbar.vala:55
+#: src/Widgets/Statusbar/Statusbar.vala:82
 msgid "GiB"
 msgstr "GiB"
 
@@ -65,19 +69,15 @@ msgstr "モニターを表示"
 msgid "Quit Monitor"
 msgstr "モニターを終了"
 
-#: src/Views/ProcessView/ProcessInfoView/OpenFilesListBox.vala:56
-msgid "Deleted"
-msgstr "削除済み"
-
-#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:19
+#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:20
 msgid "Are you sure you want to do this?"
 msgstr "この操作を実行してもよろしいですか？"
 
-#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:22
+#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:23
 msgid "Yes"
 msgstr "はい"
 
-#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:26
+#: src/Views/ProcessView/ProcessInfoView/Preventor.vala:27
 msgid "No"
 msgstr "いいえ"
 
@@ -146,27 +146,27 @@ msgstr "読み出し／書き込み"
 msgid "Cancelled write"
 msgstr "キャンセルされた書き込み"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:73
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:78
 msgid "End Process"
 msgstr "プロセスを終了"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:75
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:80
 msgid "End selected process"
 msgstr "選択したプロセスを終了します"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:79
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:84
 msgid "Kill Process"
 msgstr "プロセスを強制終了"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:80
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:85
 msgid "Kill selected process"
 msgstr "選択したプロセスを強制終了します"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:90
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:95
 msgid "Confirm kill of the process?"
 msgstr "プロセスを強制終了してもよろしいですか？"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:97
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoView.vala:102
 msgid "Confirm end of the process?"
 msgstr "プロセスを終了してもよろしいですか？"
 
@@ -179,153 +179,225 @@ msgid "Process Name"
 msgstr "プロセス名"
 
 #: src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:40
-#: src/Widgets/Headerbar/Headerbar.vala:54
 #: src/Widgets/Statusbar/Statusbar.vala:8
 msgid "CPU"
 msgstr "CPU"
 
 #: src/Views/ProcessView/ProcessTreeView/CPUProcessTreeView.vala:51
-#: src/Views/SystemView/SystemMemoryView.vala:26
-#: src/Widgets/Headerbar/Headerbar.vala:58
+#: src/Views/SystemView/SystemMemoryView.vala:13
 #: src/Widgets/Statusbar/Statusbar.vala:11
 msgid "Memory"
 msgstr "メモリー"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoCPURAM.vala:48
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoCPURAM.vala:50
 #, c-format
 msgid "CPU: %.1f%%"
 msgstr "CPU: %.1f%%"
 
-#: src/Views/ProcessView/ProcessInfoView/ProcessInfoCPURAM.vala:49
+#: src/Views/ProcessView/ProcessInfoView/ProcessInfoCPURAM.vala:51
 #, c-format
 msgid "RAM: %.1f%%"
 msgstr "RAM: %.1f%%"
 
-#: src/Views/SystemView/SystemCPUView.vala:32
-#: src/Views/SystemView/SystemMemoryView.vala:28
-msgid "UTILIZATION"
-msgstr "使用率"
+#. status: "Spinning",
+#. header: "General Preferences",
+#: src/Views/PreferencesView/PreferencesGeneralPage.vala:18
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:21
+msgid "General"
+msgstr "一般"
 
-#: src/Views/SystemView/SystemCPUView.vala:34
-#: src/Views/SystemView/SystemCPUView.vala:92
-#: src/Views/SystemView/SystemMemoryView.vala:30
-#: src/Views/SystemView/SystemMemoryView.vala:35
-msgid "Show detailed info"
-msgstr "詳細情報を表示します"
-
-#: src/Views/SystemView/SystemCPUView.vala:36
-msgid "FREQUENCY"
-msgstr "周波数"
-
-#: src/Views/SystemView/SystemCPUView.vala:40
-msgid "TEMPERATURE"
-msgstr "温度"
-
-#: src/Views/SystemView/SystemCPUView.vala:94
-#: src/Views/SystemView/SystemMemoryView.vala:37
-msgid "Hide detailed info"
-msgstr "詳細情報を非表示にします"
-
-#: src/Views/SystemView/SystemCPUView.vala:150
-#: src/Views/SystemView/SystemMemoryView.vala:98
-#, c-format
-msgid "%d%%"
-msgstr "%d%%"
-
-#: src/Views/SystemView/SystemCPUView.vala:151
-#: src/Widgets/Statusbar/Statusbar.vala:44
-msgid "GHz"
-msgstr "GHz"
-
-#: src/Views/SystemView/SystemCPUView.vala:152
-msgid "℃"
-msgstr "℃"
-
-#: src/Views/SystemView/SystemMemoryView.vala:41
-msgid "Total: "
-msgstr "合計: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:44
-msgid "Used: "
-msgstr "使用済み: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:47
-msgid "Shared: "
-msgstr "共有: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:50
-msgid "Buffered: "
-msgstr "バッファー: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:53
-msgid "Cached: "
-msgstr "キャッシュ: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:56
-msgid "Locked: "
-msgstr "ロック: "
-
-#: src/Views/SystemView/SystemMemoryView.vala:101
-#, c-format
-msgid "Total: %s"
-msgstr "合計: %s"
-
-#: src/Views/SystemView/SystemMemoryView.vala:102
-#, c-format
-msgid "Used: %s"
-msgstr "使用済み: %s"
-
-#: src/Views/SystemView/SystemMemoryView.vala:103
-#, c-format
-msgid "Shared: %s"
-msgstr "共有: %s"
-
-#: src/Views/SystemView/SystemMemoryView.vala:104
-#, c-format
-msgid "Buffered: %s"
-msgstr "バッファー: %s"
-
-#: src/Views/SystemView/SystemMemoryView.vala:105
-#, c-format
-msgid "Cached: %s"
-msgstr "キャッシュ: %s"
-
-#: src/Views/SystemView/SystemMemoryView.vala:106
-#, c-format
-msgid "Locked: %s"
-msgstr "ロック: %s"
-
-#: src/Widgets/Headerbar/Headerbar.vala:16
-msgid "Monitor"
-msgstr "モニター"
-
-#: src/Widgets/Headerbar/Headerbar.vala:24
-msgid "Settings"
-msgstr "設定"
-
-#: src/Widgets/Headerbar/Headerbar.vala:38
-msgid "Show an indicator:"
-msgstr "インジケーターを表示:"
-
-#: src/Widgets/Headerbar/Headerbar.vala:44
+#: src/Views/PreferencesView/PreferencesGeneralPage.vala:23
 msgid "Start in background:"
 msgstr "バックグラウンドで起動:"
 
-#: src/Widgets/Headerbar/Headerbar.vala:51
-msgid "Items in indicator:"
-msgstr "インジケーターに表示する項目:"
+#: src/Views/PreferencesView/PreferencesGeneralPage.vala:32
+msgid "Draw smooth lines on CPU chart (requires restart):"
+msgstr "CPU グラフの線をなめらかに描画 (再起動が必要):"
 
-#: src/Widgets/Headerbar/Headerbar.vala:62
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:12
+msgid "Show indicator in Wingpanel"
+msgstr "Wingpanel にインジケーターを表示"
+
+#. header: "Simple Pages",
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:15
+msgid "Indicator"
+msgstr "インジケーター"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:23
+msgid "Display CPU percentage"
+msgstr "CPU 使用率を表示"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:37
+msgid "Display RAM percentage"
+msgstr "RAM 使用率を表示"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:49
+msgid "Display temperature"
+msgstr "温度を表示"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:61
+msgid "Display network upload"
+msgstr "ネットワーク送信量を表示"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:73
+msgid "Display network download"
+msgstr "ネットワーク受信量を表示"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:103
+msgid "Enabled"
+msgstr "有効"
+
+#: src/Views/PreferencesView/PreferencesIndicatorPage.vala:108
+msgid "Disabled"
+msgstr "無効"
+
+#: src/Views/SystemView/SystemCPUView.vala:18
+msgid "Utilization"
+msgstr "使用率"
+
+#: src/Views/SystemView/SystemCPUView.vala:20
+msgid "Show detailed info"
+msgstr "詳細情報を表示します"
+
+#: src/Views/SystemView/SystemCPUView.vala:22
+msgid "Frequency"
+msgstr "周波数"
+
+#: src/Views/SystemView/SystemCPUView.vala:26
 msgid "Temperature"
 msgstr "温度"
 
-#: src/Widgets/Headerbar/Headerbar.vala:66
-msgid "Network up"
-msgstr "ネットワーク送信"
+#. int temperature_index = 0;
+#. foreach (var temperature in cpu.paths_temperatures.values) {
+#. debug (temperature.input);
+#. cpu_temperature_chart.update (temperature_index, int.parse (temperature.input) / 1000);
+#. temperature_index++;
+#. }]
+#: src/Views/SystemView/SystemCPUView.vala:88
+#: src/Views/SystemView/SystemGPUView.vala:79
+msgid "℃"
+msgstr "℃"
 
-#: src/Widgets/Headerbar/Headerbar.vala:70
-msgid "Network down"
-msgstr "ネットワーク受信"
+#: src/Views/SystemView/SystemCPUView.vala:134
+#: src/Widgets/Statusbar/Statusbar.vala:71
+msgid "GHz"
+msgstr "GHz"
+
+#: src/Views/SystemView/SystemCPUView.vala:161
+msgid "Threads"
+msgstr "スレッド"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:22
+msgid "Features"
+msgstr "命令セット"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:23
+msgid "Bugs"
+msgstr "バグ"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:51
+msgid "Model:"
+msgstr "モデル:"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:52
+msgid "Family:"
+msgstr "CPU ファミリー:"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:53
+msgid "Microcode ver.:"
+msgstr "マイクロコードバージョン:"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:54
+msgid "Bogomips:"
+msgstr "BogoMips:"
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:58
+msgid "L1 Instruction cache: "
+msgstr "L1 命令キャッシュ: "
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:62
+msgid "L1 Data cache: "
+msgstr "L1 データキャッシュ: "
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:66
+msgid "L1 cache: "
+msgstr "L1 キャッシュ: "
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:69
+msgid "L2 Cache size: "
+msgstr "L2 キャッシュサイズ: "
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:72
+msgid "L3 Cache size: "
+msgstr "L3 キャッシュサイズ: "
+
+#: src/Views/SystemView/SystemCPUInfoPopover.vala:75
+msgid "Address sizes: "
+msgstr "アドレスサイズ: "
+
+#: src/Views/SystemView/SystemMemoryView.vala:5
+msgid "Buffered"
+msgstr "バッファ済み"
+
+#: src/Views/SystemView/SystemMemoryView.vala:6
+msgid "Cached"
+msgstr "キャッシュ済み"
+
+#: src/Views/SystemView/SystemMemoryView.vala:7
+msgid "Locked"
+msgstr "ロック状態"
+
+#: src/Views/SystemView/SystemMemoryView.vala:8
+msgid "Total"
+msgstr "合計"
+
+#: src/Views/SystemView/SystemMemoryView.vala:9
+msgid "Used"
+msgstr "使用中"
+
+#: src/Views/SystemView/SystemMemoryView.vala:10
+msgid "Shared"
+msgstr "共有中"
+
+#: src/Views/SystemView/SystemNetworkView.vala:18
+msgid "Network"
+msgstr "ネットワーク"
+
+#: src/Views/SystemView/SystemNetworkView.vala:20
+msgid "DOWN"
+msgstr "受信"
+
+#: src/Views/SystemView/SystemNetworkView.vala:24
+msgid "UP"
+msgstr "送信"
+
+#: src/Views/SystemView/SystemStorageView.vala:20
+msgid "Storage"
+msgstr "ストレージ"
+
+#: src/Views/SystemView/SystemStorageView.vala:22
+msgid "WRITE"
+msgstr "書き込み"
+
+#: src/Views/SystemView/SystemStorageView.vala:26
+msgid "READ"
+msgstr "読み込み"
+
+#: src/Views/SystemView/SystemStorageView.vala:92
+msgid "Not mounted"
+msgstr "未マウント"
+
+#: src/Views/SystemView/SystemGPUView.vala:12
+msgid "VRAM"
+msgstr "VRAM"
+
+#: src/Views/SystemView/SystemGPUView.vala:16
+msgid "TEMPERATURE"
+msgstr "温度"
+
+#: src/Widgets/Headerbar/Headerbar.vala:22
+msgid "Settings"
+msgstr "設定"
 
 #: src/Widgets/Headerbar/Search.vala:12
 msgid "Search Process"
@@ -333,7 +405,7 @@ msgstr "プロセスを検索"
 
 #: src/Widgets/Headerbar/Search.vala:13
 msgid "Type process name or PID to search"
-msgstr "検索するにはプロセス名か PID を入力してください"
+msgstr "プロセス名か PID を入力して検索"
 
 #: src/Widgets/Statusbar/Statusbar.vala:14
 msgid "Swap"
@@ -345,20 +417,18 @@ msgstr "スワップ"
 msgid "Calculating…"
 msgstr "計算しています…"
 
-#~ msgid "CPU: "
-#~ msgstr "CPU: "
+#: src/Widgets/Statusbar/Statusbar.vala:37
+msgid "Peace"
+msgstr "平和の象徴"
 
-#~ msgid "Thread %d: %s"
-#~ msgstr "スレッド %d: %s"
+#: src/Widgets/Statusbar/Statusbar.vala:39
+msgid "Check on Github"
+msgstr "GitHub で確認"
 
-#~ msgid "CPU: % 3d%%"
-#~ msgstr "CPU: % 3d%%"
+#: src/Widgets/Statusbar/Statusbar.vala:40
+msgid "Donate 💸"
+msgstr "寄付 💸"
 
-#~ msgid "Thread %d: "
-#~ msgstr "スレッド %d: "
-
-#~ msgid "Memory: "
-#~ msgstr "メモリー: "
-
-#~ msgid "Memory: % 3d%%"
-#~ msgstr "メモリー: % 3d%%"
+#: src/Widgets/WidgetResource/WidgetResource.vala:11
+msgid "UTILIZATION"
+msgstr "使用率"


### PR DESCRIPTION
Get back 3 years fell behind :muscle:

I updated these translation files themselves from the latest source using `ninja` command before translation, so some strings look removed at a glance but these are correct changes.