### PR TITLE
Fix parsing issue for feature/bug data from csvs

### DIFF
--- a/src/Resources/CPU.vala
+++ b/src/Resources/CPU.vala
@@ -215,7 +215,7 @@ public class Monitor.CPU : Object {
                 while ((flag_data = dis.read_line ()) != null) {
 
                     int comma_position = flag_data.index_of_char (',');
-                    
+
                     if (comma_position == -1) break; // quick exit if no commas are in the line
 
                     string key = flag_data.substring (0, comma_position);
@@ -223,7 +223,7 @@ public class Monitor.CPU : Object {
                         .replace ("\"", "")
                         .replace ("  ", " ")
                         .strip ();
-                    
+
                     all_flags.set (key, value.replace ("\r", ""));
                 }
                 debug ("Parsed file %s", csv_file.get_path ());


### PR DESCRIPTION
Closes #496 

This PR addresses the issue laid out in the attached issue.

- Fixes splitting data on all commas; instead only accounts for the split between key/value
- Removes double-quotes, extra spaces from values.