### PR TITLE
Add swap data to memory info

### DIFF
--- a/src/Resources/Resources.vala
+++ b/src/Resources/Resources.vala
@@ -35,6 +35,7 @@ public class Monitor.Resources : Object {
                 memory.update ();
                 network.update ();
                 storage.update ();
+                swap.update ();
 
                 foreach (var gpu in gpu_list) {
                     gpu.update ();

--- a/src/Resources/Swap.vala
+++ b/src/Resources/Swap.vala
@@ -23,12 +23,13 @@ public class Monitor.Swap : Object {
     }
 
     public Swap () {
+        update ();
     }
 
-    private void update () {
+    public void update () {
         GTop.get_swap (out swap);
-        total = (double) (swap.total / 1024 / 1024) / 1000;
-        used = (double) (swap.used / 1024 / 1024) / 1000;
+        total = (double) (swap.total);
+        used = (double) (swap.used);
     }
 
 }

--- a/src/Views/SystemView/SystemMemoryView.vala
+++ b/src/Views/SystemView/SystemMemoryView.vala
@@ -6,6 +6,7 @@
 public class Monitor.SystemMemoryView : Monitor.WidgetResource {
     private Chart memory_chart;
     private Memory memory;
+    private Swap swap;
 
     private LabelRoundy memory_buffered_label = new LabelRoundy (_("Buffered"));
     private LabelRoundy memory_cached_label = new LabelRoundy (_("Cached"));
@@ -13,14 +14,17 @@ public class Monitor.SystemMemoryView : Monitor.WidgetResource {
     private LabelRoundy memory_total_label = new LabelRoundy (_("Total"));
     private LabelRoundy memory_used_label = new LabelRoundy (_("Used"));
     private LabelRoundy memory_shared_label = new LabelRoundy (_("Shared"));
+    private LabelRoundy swap_total_label = new LabelRoundy (_("Swap Total"));
+    private LabelRoundy swap_used_label = new LabelRoundy (_("Swap Used"));
 
     construct {
         title = (_("Memory"));
 
     }
 
-    public SystemMemoryView (Memory _memory) {
+    public SystemMemoryView (Memory _memory, Swap _swap) {
         memory = _memory;
+        swap = _swap;
 
         memory_chart = new Chart (1);
         memory_chart.set_serie_color (0, Utils.Colors.get_rgba_color (Utils.Colors.LIME_300));
@@ -53,6 +57,8 @@ public class Monitor.SystemMemoryView : Monitor.WidgetResource {
         grid.attach (memory_buffered_label, 1, 1, 1, 1);
         grid.attach (memory_cached_label, 2, 0, 1, 1);
         grid.attach (memory_locked_label, 2, 1, 1, 1);
+        grid.attach (swap_total_label, 3, 0, 1, 1);
+        grid.attach (swap_used_label, 3, 1, 1, 1);
 
         return grid;
     }
@@ -72,6 +78,9 @@ public class Monitor.SystemMemoryView : Monitor.WidgetResource {
         memory_locked_label.text = format_size ((uint64) memory.locked, IEC_UNITS);
 
         memory_shared_label.text = format_size ((uint64) memory.shared, IEC_UNITS);
+
+        swap_total_label.text = format_size ((uint64) swap.total, IEC_UNITS);
+        swap_used_label.text = format_size ((uint64) swap.used, IEC_UNITS);
     }
 
 }

--- a/src/Views/SystemView/SystemView.vala
+++ b/src/Views/SystemView/SystemView.vala
@@ -21,7 +21,7 @@ public class Monitor.SystemView : Gtk.Box {
         resources = _resources;
 
         cpu_view = new SystemCPUView (resources.cpu);
-        memory_view = new SystemMemoryView (resources.memory);
+        memory_view = new SystemMemoryView (resources.memory, resources.swap);
         network_view = new SystemNetworkView (resources.network);
         storage_view = new SystemStorageView (resources.storage);
 

--- a/src/Widgets/Statusbar/Statusbar.vala
+++ b/src/Widgets/Statusbar/Statusbar.vala
@@ -81,8 +81,8 @@ public class Monitor.Statusbar : Granite.Bin {
             swap_usage_label.label = ("%d%%").printf (sysres.swap_percentage);
             swap_usage_label.tooltip_text = ("%s / %s").printf (
                 // We get a value in GB, not bytes
-                format_size ((uint64) sysres.swap_used * 1024 * 1024 * 1024, IEC_UNITS),
-                format_size ((uint64) sysres.swap_total * 1024 * 1024 * 1024, IEC_UNITS)
+                format_size ((uint64) sysres.swap_used, IEC_UNITS),
+                format_size ((uint64) sysres.swap_total, IEC_UNITS)
             );
         }
 


### PR DESCRIPTION
This PR adds swap labels to the memory graph as brought up in discord/development on 11/16/25

<img width="431" height="205" alt="image" src="https://github.com/user-attachments/assets/f20f3858-fb32-462a-b9e4-bc22f4c297ce" />