### PR TITLE
Indicator: Port to GTK 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libgala-dev libgee-0.8-dev libglib2.0-dev libgranite-dev libgtk-4-dev libadwaita-1-dev \
-        libdbus-glib-1-dev libgtop2-dev libwingpanel-3.0-dev libudisks2-dev \
+        apt install -y libgala-dev libgee-0.8-dev libglib2.0-dev libgranite-7-dev libgtk-4-dev libadwaita-1-dev \
+        libdbus-glib-1-dev libgtop2-dev libwingpanel-9-dev libudisks2-dev \
         libxnvctrl0 libxnvctrl-dev libcurl4-gnutls-dev libflatpak-dev libjson-glib-dev \
         liblivechart-2-dev libpci-dev \
         meson valac sassc git

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install Dependencies
         run: |
           apt update
-          apt install -y libgala-dev libgee-0.8-dev libglib2.0-dev libgranite-dev libgtk-4-dev libadwaita-1-dev \
-          libdbus-glib-1-dev libgtop2-dev libwingpanel-3.0-dev libudisks2-dev \
+          apt install -y libgala-dev libgee-0.8-dev libglib2.0-dev libgranite-7-dev libgtk-4-dev libadwaita-1-dev \
+          libdbus-glib-1-dev libgtop2-dev libwingpanel-9-dev libudisks2-dev \
           libxnvctrl0 libxnvctrl-dev libcurl4-gnutls-dev libflatpak-dev libjson-glib-dev \
           liblivechart-2-dev libpci-dev \
           meson valac sassc git \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Monitor will be available from the Applications menu.
 If you plan to install WITH a wingpanel-indicator
 
 ```bash
-sudo apt install sassc valac libgtk-3-dev libgtk-4-dev libgee-0.8-dev libgranite-7-dev libgtop2-dev libadwaita-1-dev libudisks2-dev libjson-glib-dev libflatpak-dev libxnvctrl-dev liblivechart-2-dev libpci-dev libwingpanel-dev meson
+sudo apt install sassc valac libgtk-4-dev libgee-0.8-dev libgranite-7-dev libgtop2-dev libadwaita-1-dev libudisks2-dev libjson-glib-dev libflatpak-dev libxnvctrl-dev liblivechart-2-dev libpci-dev libwingpanel-9-dev meson
 ```
 
 Alternatively, if you plan to install WITHOUT a wingpanel-indicator

--- a/src/Indicator/Indicator.vala
+++ b/src/Indicator/Indicator.vala
@@ -16,7 +16,7 @@ public class Monitor.Indicator : Wingpanel.Indicator {
     }
 
     construct {
-        Gtk.IconTheme.get_default ().add_resource_path ("/io/elementary/monitor/icons");
+        Gtk.IconTheme.get_for_display (Gdk.Display.get_default ()).add_resource_path ("/io/elementary/monitor/icons");
         this.visible = false;
         display_widget = new Widgets.DisplayWidget ();
         popover_widget = new Widgets.PopoverWidget ();
@@ -83,10 +83,10 @@ public class Monitor.Indicator : Wingpanel.Indicator {
             color: @error_color;
         }
         """;
-        provider.load_from_data (css, -1);
+        provider.load_from_string (css);
 
-        Gtk.StyleContext.add_provider_for_screen (
-            Gdk.Screen.get_default (),
+        Gtk.StyleContext.add_provider_for_display (
+            Gdk.Display.get_default (),
             provider,
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         );

--- a/src/Indicator/Widgets/DisplayWidget.vala
+++ b/src/Indicator/Widgets/DisplayWidget.vala
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  */
 
-public class Monitor.Widgets.DisplayWidget : Gtk.Grid {
+public class Monitor.Widgets.DisplayWidget : Gtk.Box {
     construct {
         valign = Gtk.Align.CENTER;
 
@@ -82,14 +82,14 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Grid {
             gpu_temperature_widget.update_label (gpu_temperature);
         });
 
-        add (cpu_widget);
-        add (cpu_frequency_widget);
-        add (cpu_temperature_widget);
-        add (memory_widget);
-        add (gpu_widget);
-        add (gpu_memory_widget);
-        add (gpu_temperature_widget);
-        add (network_up_widget);
-        add (network_down_widget);
+        append (cpu_widget);
+        append (cpu_frequency_widget);
+        append (cpu_temperature_widget);
+        append (memory_widget);
+        append (gpu_widget);
+        append (gpu_memory_widget);
+        append (gpu_temperature_widget);
+        append (network_up_widget);
+        append (network_down_widget);
     }
 }

--- a/src/Indicator/Widgets/IndicatorWidget.vala
+++ b/src/Indicator/Widgets/IndicatorWidget.vala
@@ -18,15 +18,18 @@ public class Monitor.IndicatorWidget : Gtk.Box {
     }
 
     construct {
-        var icon = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.SMALL_TOOLBAR);
+        var icon = new Gtk.Image.from_icon_name (icon_name);
 
         label = new Gtk.Label (Utils.NOT_AVAILABLE) {
-            margin = 2,
+            margin_start = 2,
+            margin_end = 2,
+            margin_top = 2,
+            margin_bottom = 2,
             width_chars = 4,
         };
 
-        pack_start (icon);
-        pack_start (label);
+        append (icon);
+        append (label);
     }
 
     public virtual void update_label (Value value) {

--- a/src/Indicator/Widgets/IndicatorWidgetPercentage.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetPercentage.vala
@@ -12,15 +12,15 @@ public class Monitor.IndicatorWidgetPercentage : Monitor.IndicatorWidget {
         uint percentage = value.get_uint ();
 
         label.label = "%u%%".printf (percentage);
-        label.get_style_context ().remove_class ("monitor-indicator-label-warning");
-        label.get_style_context ().remove_class ("monitor-indicator-label-critical");
+        label.remove_css_class ("monitor-indicator-label-warning");
+        label.remove_css_class ("monitor-indicator-label-critical");
 
         if (percentage > 80) {
-            label.get_style_context ().add_class ("monitor-indicator-label-warning");
+            label.add_css_class ("monitor-indicator-label-warning");
         }
 
         if (percentage > 90) {
-            label.get_style_context ().add_class ("monitor-indicator-label-critical");
+            label.add_css_class ("monitor-indicator-label-critical");
         }
     }
 }

--- a/src/Indicator/Widgets/PopoverWidget.vala
+++ b/src/Indicator/Widgets/PopoverWidget.vala
@@ -3,10 +3,10 @@
  * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
  */
 
-public class Monitor.Widgets.PopoverWidget : Gtk.Grid {
+public class Monitor.Widgets.PopoverWidget : Gtk.Box {
     /* Button to hide the indicator */
-    private Gtk.ModelButton show_monitor_button;
-    private Gtk.ModelButton quit_monitor_button;
+    private Wingpanel.PopoverMenuItem show_monitor_button;
+    private Wingpanel.PopoverMenuItem quit_monitor_button;
 
     public signal void quit_monitor ();
     public signal void show_monitor ();
@@ -14,17 +14,17 @@ public class Monitor.Widgets.PopoverWidget : Gtk.Grid {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        show_monitor_button = new Gtk.ModelButton ();
+        show_monitor_button = new Wingpanel.PopoverMenuItem ();
         show_monitor_button.text = _("Show Monitor");
         show_monitor_button.hexpand = true;
-        quit_monitor_button = new Gtk.ModelButton ();
+        quit_monitor_button = new Wingpanel.PopoverMenuItem ();
         quit_monitor_button.text = _("Quit Monitor");
         quit_monitor_button.hexpand = true;
         show_monitor_button.clicked.connect (() => show_monitor ());
         quit_monitor_button.clicked.connect (() => quit_monitor ());
 
-        add (show_monitor_button);
-        add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-        add (quit_monitor_button);
+        append (show_monitor_button);
+        append (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+        append (quit_monitor_button);
     }
 }

--- a/src/Indicator/meson.build
+++ b/src/Indicator/meson.build
@@ -13,8 +13,8 @@ source_indicator_files = [
     meson.project_source_root() / 'src' / 'Utils.vala',
 ]
 
-wingpanel_dep = dependency('wingpanel', version: '>=2.1.0')
-gtk_dep = dependency('gtk+-3.0')
+wingpanel_dep = dependency('wingpanel-9')
+gtk_dep = dependency('gtk4', version: '>= 4.12')
 
 indicator_dependencies = [
     wingpanel_dep,


### PR DESCRIPTION
Fixes #481

Merging this into main means no further releases for OS 8 because this requires Wingpanel 9 that would be only available for OS 9.

You need to install Wingpanel 9 from source to test this branch on OS 8.

<img width="655" height="342" alt="Screenshot_elementary-8-daily_2026-08-01_21:23:22" src="https://github.com/user-attachments/assets/a29a3c80-b944-4100-a82c-d7727089f3c1" />
