### PR TITLE
Some proposed improvements

### DIFF
--- a/data/io.elementary.monitor.gschema.xml
+++ b/data/io.elementary.monitor.gschema.xml
@@ -60,6 +60,11 @@
       <summary>To show network down bandwidth in Monitor Indicator or not</summary>
       <description>To show network down bandwidth in Monitor Indicator or not</description>
     </key>
+    <key type='b' name="indicator-network-use-bits-state">
+      <default>false</default>
+      <summary>To show network bandwidth in in bits instead of bytes per second</summary>
+      <description>To show network bandwidth in in bits instead of bytes per second</description>
+    </key>
     <key type='b' name="indicator-gpu-state">
       <default>false</default>
       <summary>To show GPU used percentage in Monitor Indicator or not</summary>

--- a/src/Indicator/Services/DBusClient.vala
+++ b/src/Indicator/Services/DBusClient.vala
@@ -15,6 +15,7 @@ public interface Monitor.DBusClientInterface : Object {
     public signal void indicator_memory_state (bool state);
     public signal void indicator_network_up_state (bool state);
     public signal void indicator_network_down_state (bool state);
+    public signal void indicator_network_use_bits_state (bool state);
     public signal void indicator_gpu_state (bool state);
     public signal void indicator_gpu_memory_state (bool state);
     public signal void indicator_gpu_temperature_state (bool state);

--- a/src/Indicator/Widgets/DisplayWidget.vala
+++ b/src/Indicator/Widgets/DisplayWidget.vala
@@ -29,6 +29,9 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Box {
             memory_widget.visible = Indicator.settings.get_boolean ("indicator-memory-state");
             network_up_widget.visible = Indicator.settings.get_boolean ("indicator-network-upload-state");
             network_down_widget.visible = Indicator.settings.get_boolean ("indicator-network-download-state");
+            bool use_bits = Indicator.settings.get_boolean ("indicator-network-use-bits-state");
+            network_up_widget.use_bits = use_bits;
+            network_down_widget.use_bits = use_bits;
             gpu_widget.visible = Indicator.settings.get_boolean ("indicator-gpu-state");
             gpu_memory_widget.visible = Indicator.settings.get_boolean ("indicator-gpu-memory-state");
             gpu_temperature_widget.visible = Indicator.settings.get_boolean ("indicator-gpu-temperature-state");
@@ -40,6 +43,10 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Box {
         dbusclient.interface.indicator_memory_state.connect ((state) => memory_widget.visible = state);
         dbusclient.interface.indicator_network_up_state.connect ((state) => network_up_widget.visible = state);
         dbusclient.interface.indicator_network_down_state.connect ((state) => network_down_widget.visible = state);
+        dbusclient.interface.indicator_network_use_bits_state.connect ((state) => {
+            network_up_widget.use_bits = state;
+            network_down_widget.use_bits = state;
+        });
         dbusclient.interface.indicator_gpu_state.connect ((state) => gpu_widget.visible = state);
         dbusclient.interface.indicator_gpu_memory_state.connect ((state) => gpu_memory_widget.visible = state);
         dbusclient.interface.indicator_gpu_temperature_state.connect ((state) => gpu_temperature_widget.visible = state);

--- a/src/Indicator/Widgets/DisplayWidget.vala
+++ b/src/Indicator/Widgets/DisplayWidget.vala
@@ -89,7 +89,7 @@ public class Monitor.Widgets.DisplayWidget : Gtk.Box {
         append (gpu_widget);
         append (gpu_memory_widget);
         append (gpu_temperature_widget);
-        append (network_up_widget);
         append (network_down_widget);
+        append (network_up_widget);
     }
 }

--- a/src/Indicator/Widgets/IndicatorWidget.vala
+++ b/src/Indicator/Widgets/IndicatorWidget.vala
@@ -32,5 +32,7 @@ public class Monitor.IndicatorWidget : Gtk.Box {
         append (label);
     }
 
-    public abstract void update_label (Value value);
+    public virtual void update_label (Value value) {
+        // NOP; should be overridden by child classes
+    }
 }

--- a/src/Indicator/Widgets/IndicatorWidget.vala
+++ b/src/Indicator/Widgets/IndicatorWidget.vala
@@ -32,7 +32,5 @@ public class Monitor.IndicatorWidget : Gtk.Box {
         append (label);
     }
 
-    public virtual void update_label (Value value) {
-        // NOP; should be overridden by child classes
-    }
+    public abstract void update_label (Value value);
 }

--- a/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
@@ -17,22 +17,6 @@ public class Monitor.IndicatorWidgetBandwidth : Monitor.IndicatorWidget {
     public override void update_label (Value value) {
         uint64 bandwidth = value.get_uint64 ();
 
-        label.label = format_network_speed (bandwidth, use_bits);
-    }
-
-    public string format_network_speed (uint64 bandwidth, bool use_bits = false) {
-        const int SCALE = 1000;
-        bandwidth = bandwidth * (use_bits ? 8 : 1);
-        string unit_suffix = use_bits ? "bps" : "Bps";
-        string[] units = { "", "K", "M", "G", "T" };
-
-        int unit_index = 0;
-
-        while (bandwidth >= SCALE && unit_index < units.length - 1) {
-            bandwidth /= SCALE;
-            unit_index++;
-        }
-
-        return "%llu %s%s".printf (bandwidth, units[unit_index], unit_suffix);
+        label.label = Utils.Strings.format_network_speed (bandwidth, use_bits);
     }
 }

--- a/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
@@ -11,6 +11,22 @@ public class Monitor.IndicatorWidgetBandwidth : Monitor.IndicatorWidget {
     public override void update_label (Value value) {
         uint64 bandwidth = value.get_uint64 ();
 
-        label.label = format_size (bandwidth);
+        label.label = format_network_speed (bandwidth);
+    }
+
+    private string format_network_speed (uint64 bandwidth, bool use_bits = false) {
+        const int SCALE = 1000;
+        bandwidth = bandwidth * (use_bits ? 8 : 1);
+        string unit_suffix = use_bits ? "bps" : "Bps";
+        string[] units = { "", "K", "M", "G", "T" };
+
+        int unit_index = 0;
+
+        while (bandwidth >= SCALE && unit_index < units.length - 1) {
+            bandwidth /= SCALE;
+            unit_index++;
+        }
+
+        return "%llu %s%s".printf (bandwidth, units[unit_index], unit_suffix);
     }
 }

--- a/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
@@ -4,6 +4,8 @@
  */
 
 public class Monitor.IndicatorWidgetBandwidth : Monitor.IndicatorWidget {
+    public bool use_bits = false;
+
     public IndicatorWidgetBandwidth (string icon_name) {
         base (icon_name);
     }
@@ -15,10 +17,10 @@ public class Monitor.IndicatorWidgetBandwidth : Monitor.IndicatorWidget {
     public override void update_label (Value value) {
         uint64 bandwidth = value.get_uint64 ();
 
-        label.label = format_network_speed (bandwidth);
+        label.label = format_network_speed (bandwidth, use_bits);
     }
 
-    private string format_network_speed (uint64 bandwidth, bool use_bits = false) {
+    public string format_network_speed (uint64 bandwidth, bool use_bits = false) {
         const int SCALE = 1000;
         bandwidth = bandwidth * (use_bits ? 8 : 1);
         string unit_suffix = use_bits ? "bps" : "Bps";

--- a/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetBandwidth.vala
@@ -8,6 +8,10 @@ public class Monitor.IndicatorWidgetBandwidth : Monitor.IndicatorWidget {
         base (icon_name);
     }
 
+    construct {
+        label.width_chars = 8;
+    }
+
     public override void update_label (Value value) {
         uint64 bandwidth = value.get_uint64 ();
 

--- a/src/Indicator/Widgets/IndicatorWidgetFrequency.vala
+++ b/src/Indicator/Widgets/IndicatorWidgetFrequency.vala
@@ -8,9 +8,13 @@ public class Monitor.IndicatorWidgetFrequency : Monitor.IndicatorWidget {
         base (icon_name);
     }
 
+    construct {
+        label.width_chars = 8;
+    }
+
     public override void update_label (Value value) {
         double frequency = value.get_double ();
 
-        label.label = ("%.2f %s").printf (frequency, _("GHz"));
+        label.label = Utils.Strings.format_frequency (frequency);
     }
 }

--- a/src/Resources/CPU.vala
+++ b/src/Resources/CPU.vala
@@ -44,8 +44,8 @@ public class Monitor.CPU : Object {
     private double _frequency;
     public double frequency {
         get {
-            // Convert kHz to GHz
-            return (double) (_frequency / 1000000);
+            // Convert kHz to MHz
+            return (double) (_frequency / 1000);
         }
     }
     public double temperature_mean {

--- a/src/Services/DBusServer.vala
+++ b/src/Services/DBusServer.vala
@@ -22,6 +22,7 @@ public class Monitor.DBusServer : Object {
     public signal void indicator_memory_state (bool state);
     public signal void indicator_network_up_state (bool state);
     public signal void indicator_network_down_state (bool state);
+    public signal void indicator_network_use_bits_state (bool state);
     public signal void indicator_gpu_state (bool state);
     public signal void indicator_gpu_memory_state (bool state);
     public signal void indicator_gpu_temperature_state (bool state);

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -49,6 +49,21 @@ public class Monitor.Utils.Strings {
         return pretty;
     }
 
+    public static string format_network_speed (uint64 bandwidth, bool use_bits = false) {
+        const int SCALE = 1000;
+        bandwidth = bandwidth * (use_bits ? 8 : 1);
+        string unit_suffix = use_bits ? "bps" : "Bps";
+        string[] units = { "", "K", "M", "G", "T" };
+
+        int unit_index = 0;
+
+        while (bandwidth >= SCALE && unit_index < units.length - 1) {
+            bandwidth /= SCALE;
+            unit_index++;
+        }
+
+        return "%llu %s%s".printf (bandwidth, units[unit_index], unit_suffix);
+    }
 }
 
 public class Monitor.Utils.Colors : Object {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -64,6 +64,14 @@ public class Monitor.Utils.Strings {
 
         return "%llu %s%s".printf (bandwidth, units[unit_index], unit_suffix);
     }
+
+    public static string format_frequency (double mhz) {
+        if (mhz >= 1000.0) {
+            return "%.2f %s".printf (mhz / 1000.0, _("GHz"));
+        }
+
+        return "%.0f %s".printf (mhz, _("MHz"));
+    }
 }
 
 public class Monitor.Utils.Colors : Object {

--- a/src/Views/PreferencesView.vala
+++ b/src/Views/PreferencesView.vala
@@ -89,6 +89,11 @@ public class Monitor.PreferencesView : Granite.Bin {
             dbusserver.indicator_network_down_state (network_download_check.active);
         });
 
+        var network_use_bits_check = new Gtk.CheckButton.with_label (_("Network use bits"));
+        network_use_bits_check.toggled.connect (() => {
+            dbusserver.indicator_network_use_bits_state (network_use_bits_check.active);
+        });
+
         var gpu_check = new Gtk.CheckButton.with_label (_("GPU percentage"));
         gpu_check.toggled.connect (() => {
             dbusserver.indicator_gpu_state (gpu_check.active);
@@ -124,6 +129,7 @@ public class Monitor.PreferencesView : Granite.Bin {
         indicator_options_box.append (new Gtk.Separator (HORIZONTAL));
         indicator_options_box.append (network_download_check);
         indicator_options_box.append (network_upload_check);
+        indicator_options_box.append (network_use_bits_check);
 
         var indicator_options_revealer = new Gtk.Revealer () {
             child = indicator_options_box
@@ -158,5 +164,6 @@ public class Monitor.PreferencesView : Granite.Bin {
         settings.bind ("indicator-gpu-state", gpu_check, "active", DEFAULT);
         settings.bind ("indicator-network-download-state", network_download_check, "active", DEFAULT);
         settings.bind ("indicator-network-upload-state", network_upload_check, "active", DEFAULT);
+        settings.bind ("indicator-network-use-bits-state", network_use_bits_check, "active", DEFAULT);
     }
 }

--- a/src/Views/PreferencesView.vala
+++ b/src/Views/PreferencesView.vala
@@ -122,8 +122,8 @@ public class Monitor.PreferencesView : Granite.Bin {
         indicator_options_box.append (gpu_memory_check);
         indicator_options_box.append (gpu_temp_check);
         indicator_options_box.append (new Gtk.Separator (HORIZONTAL));
-        indicator_options_box.append (network_upload_check);
         indicator_options_box.append (network_download_check);
+        indicator_options_box.append (network_upload_check);
 
         var indicator_options_revealer = new Gtk.Revealer () {
             child = indicator_options_box

--- a/src/Views/SystemView/SystemCPUView.vala
+++ b/src/Views/SystemView/SystemCPUView.vala
@@ -126,7 +126,7 @@ public class Monitor.SystemCPUView : Monitor.WidgetResource {
         }
 
         main_metric_value = ("%d%%").printf (cpu.percentage);
-        cpu_frequency_label.text = ("%.2f %s").printf (cpu.frequency, _("GHz"));
+        cpu_frequency_label.text = Utils.Strings.format_frequency (cpu.frequency);
     }
 
     private Gtk.Grid grid_core_labels () {

--- a/src/Views/SystemView/SystemNetworkView.vala
+++ b/src/Views/SystemView/SystemNetworkView.vala
@@ -11,6 +11,8 @@ public class Monitor.SystemNetworkView : Gtk.Grid {
     private LabelRoundy network_upload_label;
     private LabelRoundy network_download_label;
 
+    public bool use_bits = false;
+
     construct {
         margin_top = 12;
         margin_bottom = 12;
@@ -60,8 +62,8 @@ public class Monitor.SystemNetworkView : Gtk.Grid {
         double up_bytes = network.bytes_out;
         double down_bytes = network.bytes_in;
         if (up_bytes >= 0 && down_bytes >= 0) {
-            network_download_label.text = ("%s/s").printf (format_size ((uint64) down_bytes, IEC_UNITS));
-            network_upload_label.text = ("%s/s").printf (format_size ((uint64) up_bytes, IEC_UNITS));
+            network_download_label.text = Utils.Strings.format_network_speed ((uint64) down_bytes, use_bits);
+            network_upload_label.text = Utils.Strings.format_network_speed ((uint64) up_bytes, use_bits);
             network_chart.update (0, up_bytes);
             network_chart.update (1, down_bytes);
         }

--- a/src/Views/SystemView/SystemView.vala
+++ b/src/Views/SystemView/SystemView.vala
@@ -50,6 +50,13 @@ public class Monitor.SystemView : Gtk.Box {
         }
 
         append (scrolled_window);
+
+        unowned var dbusclient = DBusClient.get_default ();
+        dbusclient.interface.indicator_network_use_bits_state.connect ((state) => {
+            network_view.use_bits = state;
+        });
+        Settings settings = new Settings ("io.elementary.monitor.settings");
+        network_view.use_bits = settings.get_boolean ("indicator-network-use-bits-state");
     }
 
     public void update () {

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,7 @@ source_app_files = [
     # Services
     'Services/DBusServer.vala',
     'Services/Appearance.vala',
+    'Indicator/Services/DBusClient.vala',
 
     # Resources
     'Resources/Resources.vala',


### PR DESCRIPTION
Following proposed changes:
- Swap network upload/download indicators (system chart already is this way). People typically prefer to see the downloads more than uploads?
- Add a "use bits" preference to show network bandwidth in bits-per-second instead of bytes.
- Add custom bandwidth format string util method.
- Show sub-GHz CPU frequency as MHz instead of always GHz.
- Increase some indicator widths to prevent widgets jumping around when label texts change.